### PR TITLE
Add property-aware training heads and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ Il comando utilizza `LabelEmbedModel`, inizializza i prototipi delle classi dai
 rispettivi testi e salva un pacchetto di export (`export/`) contenente pesi
 `safetensors`, tokenizer, mapping e ontologia.
 
+Quando il dataset fornisce le colonne aggiuntive `properties` e
+`property_schema`, il trainer abilita automaticamente una testa secondaria che
+predice la presenza degli slot e i valori numerici associati. Il contributo
+delle due componenti può essere bilanciato tramite:
+
+* `--property_presence_weight` per la loss multi-label di presenza (default `1.0`).
+* `--property_regression_weight` per la loss di regressione sugli slot numerici
+  (default `1.0`).
+
 > Suggerimento: `atipiqal/roBERTino` fornisce un backbone già specializzato per
 > la classificazione BIM e rappresenta il punto di partenza ideale per il label
 > model. In alternativa è possibile riutilizzare qualsiasi checkpoint Hugging
@@ -138,7 +147,9 @@ robimb train hier \
 
 Viene addestrato `MultiTaskBERTMasked` con maschera ontologica, ArcFace
 opzionale e pesi di classe. Anche in questo caso il comando crea `export/` con il
-modello pronto all'uso.
+modello pronto all'uso. La testata sulle proprietà è condivisa con il trainer a
+label embedding e usa gli stessi argomenti facoltativi `--property_presence_weight`
+e `--property_regression_weight` per regolare le nuove perdite.
 
 ### 5. Validazione
 

--- a/src/robimb/training/label_trainer.py
+++ b/src/robimb/training/label_trainer.py
@@ -24,6 +24,11 @@ from transformers import (
 )
 
 from ..models.label_model import LabelEmbedModel, load_label_embed_model
+from ..training.property_utils import (
+    PropertyMetadata,
+    build_property_metadata,
+    build_property_targets,
+)
 from ..utils.data_utils import build_mask_and_report, load_jsonl_to_df
 from ..utils.metrics_utils import make_compute_metrics
 from ..utils.ontology_utils import load_label_maps
@@ -65,6 +70,8 @@ class LabelTrainingArgs:
     publish_hub: bool = False
     hub_repo: Optional[str] = None
     hub_private: bool = False
+    property_presence_weight: float = 1.0
+    property_regression_weight: float = 1.0
 
 
 class SanitizeGrads(TrainerCallback):
@@ -108,12 +115,14 @@ def _load_label_texts(path: Optional[str], fallback: Iterable[str]) -> List[str]
     return output
 
 
-def _build_dataset(path: str, max_length: int, tokenizer) -> Dataset:
-    df = load_jsonl_to_df(path)
+def _build_dataset(
+    df: pd.DataFrame,
+    max_length: int,
+    tokenizer,
+    property_meta: Optional[PropertyMetadata],
+) -> Dataset:
     if not {"text", "super_label", "cat_label"}.issubset(df.columns):
-        raise ValueError(
-            f"Dataset {path} must contain 'text', 'super_label' and 'cat_label' columns."
-        )
+        raise ValueError("Dataset must contain 'text', 'super_label' and 'cat_label' columns.")
 
     def _tokenize(batch: Dict[str, List]):
         tokens = tokenizer(
@@ -124,10 +133,29 @@ def _build_dataset(path: str, max_length: int, tokenizer) -> Dataset:
         )
         tokens["super_labels"] = batch["super_label"]
         tokens["cat_labels"] = batch["cat_label"]
+        if property_meta is not None and property_meta.has_properties():
+            properties = batch.get("properties", [{} for _ in batch["cat_label"]])
+            mask, presence, reg_targets, reg_mask = build_property_targets(
+                properties,
+                batch["cat_label"],
+                property_meta,
+            )
+            tokens["property_slot_mask"] = mask.tolist()
+            tokens["property_presence_labels"] = presence.tolist()
+            tokens["property_regression_targets"] = reg_targets.tolist()
+            tokens["property_regression_mask"] = reg_mask.tolist()
+        else:
+            empty = [[0.0] * 0 for _ in batch["cat_label"]]
+            tokens["property_slot_mask"] = empty
+            tokens["property_presence_labels"] = empty
+            tokens["property_regression_targets"] = empty
+            tokens["property_regression_mask"] = empty
         return tokens
 
     dataset = Dataset.from_pandas(df, preserve_index=False)
-    return dataset.map(_tokenize, batched=True, remove_columns=df.columns.tolist())
+    keep_cols = {"properties", "property_schema"}
+    remove_cols = [col for col in df.columns.tolist() if col not in keep_cols]
+    return dataset.map(_tokenize, batched=True, remove_columns=remove_cols)
 
 
 def _param_groups(model: LabelEmbedModel, lr_head: float, lr_encoder: float, weight_decay: float):
@@ -189,6 +217,36 @@ def train_label_model(args: LabelTrainingArgs) -> Tuple[Trainer, Dict[str, float
     config.label_texts_cat = label_texts_cat
     config.backbone_src = args.base_model if args.backbone_src is None else args.backbone_src
 
+    train_df = load_jsonl_to_df(args.train_jsonl)
+    eval_df = load_jsonl_to_df(args.val_jsonl)
+
+    property_meta = build_property_metadata((train_df, eval_df), num_cat)
+    if property_meta.has_properties():
+        config.num_properties = property_meta.num_slots
+        config.property_slot_names = list(property_meta.slot_names)
+        config.property_numeric_mask = property_meta.numeric_mask.astype(int).tolist()
+        config.property_cat_mask = property_meta.cat_property_mask.tolist()
+        config.property_presence_weight = float(args.property_presence_weight)
+        config.property_regression_weight = float(args.property_regression_weight)
+    else:
+        config.num_properties = 0
+        config.property_slot_names = []
+        config.property_numeric_mask = []
+        config.property_cat_mask = []
+        config.property_presence_weight = float(args.property_presence_weight)
+        config.property_regression_weight = float(args.property_regression_weight)
+
+    property_cat_mask_tensor = (
+        torch.tensor(property_meta.cat_property_mask, dtype=torch.bool)
+        if property_meta.has_properties()
+        else None
+    )
+    property_numeric_tensor = (
+        torch.tensor(property_meta.numeric_mask, dtype=torch.bool)
+        if property_meta.has_properties()
+        else None
+    )
+
     if args.init_from:
         print(f"[INFO] Ripartenza da {args.init_from}")
         model = load_label_embed_model(
@@ -200,6 +258,12 @@ def train_label_model(args: LabelTrainingArgs) -> Tuple[Trainer, Dict[str, float
                 "num_labels_cat": num_cat,
                 "mask_matrix": mask_matrix.tolist(),
                 "nd_id": nd_id,
+                "num_properties": config.num_properties,
+                "property_slot_names": config.property_slot_names,
+                "property_numeric_mask": config.property_numeric_mask,
+                "property_cat_mask": config.property_cat_mask,
+                "property_presence_weight": float(args.property_presence_weight),
+                "property_regression_weight": float(args.property_regression_weight),
             },
         )
     else:
@@ -218,6 +282,11 @@ def train_label_model(args: LabelTrainingArgs) -> Tuple[Trainer, Dict[str, float
             nd_id=nd_id,
             freeze_encoder=args.freeze_encoder,
             train_label_emb=args.train_label_emb,
+            num_properties=config.num_properties,
+            property_cat_mask=property_cat_mask_tensor,
+            property_numeric_mask=property_numeric_tensor,
+            property_presence_weight=args.property_presence_weight,
+            property_regression_weight=args.property_regression_weight,
         )
 
     if args.unfreeze_last and not args.freeze_encoder:
@@ -229,8 +298,8 @@ def train_label_model(args: LabelTrainingArgs) -> Tuple[Trainer, Dict[str, float
                 for param in encoder_layers.layer[i].parameters():
                     param.requires_grad = False
 
-    train_dataset = _build_dataset(args.train_jsonl, args.max_length, tokenizer)
-    eval_dataset = _build_dataset(args.val_jsonl, args.max_length, tokenizer)
+    train_dataset = _build_dataset(train_df, args.max_length, tokenizer, property_meta)
+    eval_dataset = _build_dataset(eval_df, args.max_length, tokenizer, property_meta)
 
     data_collator = DataCollatorWithPadding(tokenizer=tokenizer, pad_to_multiple_of=8)
 
@@ -256,6 +325,16 @@ def train_label_model(args: LabelTrainingArgs) -> Tuple[Trainer, Dict[str, float
         hub_private_repo=args.hub_private,
         report_to=["tensorboard"],
         save_total_limit=3,
+        label_names=[
+            "super_labels",
+            "cat_labels",
+            "property_slot_mask",
+            "property_presence_labels",
+            "property_regression_targets",
+            "property_regression_mask",
+        ]
+        if property_meta.has_properties()
+        else ["super_labels", "cat_labels"],
     )
 
     optimizer = AdamW(_param_groups(model, args.lr_head, args.lr_encoder, args.weight_decay))
@@ -268,7 +347,7 @@ def train_label_model(args: LabelTrainingArgs) -> Tuple[Trainer, Dict[str, float
         tokenizer=tokenizer,
         data_collator=data_collator,
         optimizers=(optimizer, None),
-        compute_metrics=make_compute_metrics(num_super, num_cat),
+        compute_metrics=make_compute_metrics(num_super, num_cat, property_meta),
         callbacks=[SanitizeGrads()],
     )
 
@@ -291,6 +370,12 @@ def train_label_model(args: LabelTrainingArgs) -> Tuple[Trainer, Dict[str, float
     tokenizer.save_pretrained(export_dir)
     with open(export_dir / "metrics.json", "w", encoding="utf-8") as handle:
         json.dump(metrics, handle, indent=2)
+    property_metrics = {
+        key: value for key, value in metrics.items() if key.startswith("eval_prop_")
+    }
+    if property_metrics:
+        with open(export_dir / "property_metrics.json", "w", encoding="utf-8") as handle:
+            json.dump(property_metrics, handle, indent=2)
     with open(out_dir / "mask_report.json", "w", encoding="utf-8") as handle:
         json.dump(mask_report, handle, indent=2)
     shutil.copyfile(args.label_maps, export_dir / "label_maps.json")
@@ -334,6 +419,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--publish_hub", action="store_true")
     parser.add_argument("--hub_repo", default=None)
     parser.add_argument("--hub_private", action="store_true")
+    parser.add_argument("--property_presence_weight", type=float, default=1.0)
+    parser.add_argument("--property_regression_weight", type=float, default=1.0)
     return parser
 
 

--- a/src/robimb/training/property_utils.py
+++ b/src/robimb/training/property_utils.py
@@ -1,0 +1,170 @@
+"""Utility helpers to deal with property prediction targets."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["PropertyMetadata", "build_property_metadata", "build_property_targets"]
+
+
+SUPPORTED_SCHEMA_TYPES = {"float", "int", "number", "enum", "bool", "boolean"}
+NUMERIC_TYPES = {"float", "int", "number"}
+
+
+@dataclass
+class PropertyMetadata:
+    """Aggregated information about property slots present in the dataset."""
+
+    slot_to_idx: Mapping[str, int]
+    slot_names: Sequence[str]
+    numeric_mask: np.ndarray
+    cat_property_mask: np.ndarray
+
+    @property
+    def num_slots(self) -> int:
+        return len(self.slot_names)
+
+    def has_properties(self) -> bool:
+        return self.num_slots > 0
+
+
+def _normalise_schema_type(raw: Optional[Mapping[str, object]]) -> Optional[str]:
+    if raw is None:
+        return None
+    value = raw.get("type") if isinstance(raw, Mapping) else None
+    if not isinstance(value, str):
+        return None
+    lowered = value.lower().strip()
+    if lowered not in SUPPORTED_SCHEMA_TYPES:
+        return None
+    return lowered
+
+
+def build_property_metadata(
+    dataframes: Iterable[pd.DataFrame],
+    num_cat: int,
+) -> PropertyMetadata:
+    """Collect slot metadata from the provided dataframes."""
+
+    slot_to_idx: Dict[str, int] = {}
+    slot_names: List[str] = []
+    numeric_mask: List[bool] = []
+    cat_to_slots: List[set[int]] = [set() for _ in range(num_cat)]
+
+    for df in dataframes:
+        if "property_schema" not in df.columns or "cat_label" not in df.columns:
+            continue
+        for cat_label, schema in zip(df["cat_label"], df["property_schema"]):
+            if not isinstance(schema, Mapping):
+                continue
+            slots = schema.get("slots")
+            if not isinstance(slots, Mapping):
+                continue
+            try:
+                cat_idx = int(cat_label)
+            except (TypeError, ValueError):
+                continue
+            if cat_idx < 0 or cat_idx >= num_cat:
+                continue
+            for slot_name, slot_schema in slots.items():
+                if not isinstance(slot_name, str):
+                    continue
+                norm_type = _normalise_schema_type(slot_schema)
+                if norm_type is None:
+                    continue
+                if slot_name not in slot_to_idx:
+                    slot_to_idx[slot_name] = len(slot_names)
+                    slot_names.append(slot_name)
+                    numeric_mask.append(norm_type in NUMERIC_TYPES)
+                idx = slot_to_idx[slot_name]
+                cat_to_slots[cat_idx].add(idx)
+
+    if not slot_names:
+        empty_mask = np.zeros((num_cat, 0), dtype=np.float32)
+        return PropertyMetadata({}, [], np.zeros(0, dtype=bool), empty_mask)
+
+    cat_property_mask = np.zeros((num_cat, len(slot_names)), dtype=np.float32)
+    for cat_idx, slot_indices in enumerate(cat_to_slots):
+        if not slot_indices:
+            continue
+        cat_property_mask[cat_idx, list(slot_indices)] = 1.0
+
+    return PropertyMetadata(
+        slot_to_idx=slot_to_idx,
+        slot_names=slot_names,
+        numeric_mask=np.asarray(numeric_mask, dtype=bool),
+        cat_property_mask=cat_property_mask,
+    )
+
+
+def _clean_value(value: object) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        value = value[0]
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        stripped = stripped.replace(",", ".")
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+def build_property_targets(
+    batch_properties: Sequence[MutableMapping[str, object] | Mapping[str, object] | None],
+    batch_cat_labels: Sequence[int],
+    metadata: PropertyMetadata,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Create masks and targets for property prediction."""
+
+    num_props = metadata.num_slots
+    batch_size = len(batch_cat_labels)
+    mask = np.zeros((batch_size, num_props), dtype=np.float32)
+    presence = np.zeros((batch_size, num_props), dtype=np.float32)
+    regression_targets = np.zeros((batch_size, num_props), dtype=np.float32)
+    regression_mask = np.zeros((batch_size, num_props), dtype=np.float32)
+
+    if num_props == 0:
+        return mask, presence, regression_targets, regression_mask
+
+    numeric_mask = metadata.numeric_mask
+    cat_mask = metadata.cat_property_mask
+
+    for row_idx, cat_label in enumerate(batch_cat_labels):
+        try:
+            cat_id = int(cat_label)
+        except (TypeError, ValueError):
+            continue
+        if cat_id < 0 or cat_id >= cat_mask.shape[0]:
+            continue
+        allowed = cat_mask[cat_id]
+        mask[row_idx] = allowed
+
+        props = batch_properties[row_idx] if row_idx < len(batch_properties) else None
+        if not isinstance(props, Mapping):
+            continue
+        for prop_name, raw_value in props.items():
+            idx = metadata.slot_to_idx.get(prop_name)
+            if idx is None:
+                continue
+            if allowed[idx] == 0:
+                continue
+            presence[row_idx, idx] = 1.0
+            if numeric_mask[idx]:
+                value = _clean_value(raw_value)
+                if value is not None:
+                    regression_targets[row_idx, idx] = value
+                    regression_mask[row_idx, idx] = 1.0
+
+    return mask, presence, regression_targets, regression_mask

--- a/src/robimb/utils/metrics_utils.py
+++ b/src/robimb/utils/metrics_utils.py
@@ -9,16 +9,42 @@ from sklearn.metrics import accuracy_score, f1_score
 __all__ = ["make_compute_metrics"]
 
 
-def make_compute_metrics(num_super: int, num_cat: int):
+def _to_numpy(value):
+    if value is None:
+        return None
+    if hasattr(value, "detach"):
+        return value.detach().cpu().numpy()
+    return np.asarray(value)
+
+
+def make_compute_metrics(num_super: int, num_cat: int, property_meta=None):
     def _compute(eval_pred) -> Dict[str, float]:
         preds = getattr(eval_pred, "predictions", eval_pred)
         labels = getattr(eval_pred, "label_ids", None)
         if isinstance(preds, (tuple, list)):
-            preds = preds[0]
-        if hasattr(preds, "detach"):
-            preds = preds.detach().cpu().numpy()
-        logits = np.asarray(preds)
-        logits = np.nan_to_num(logits, nan=0.0, posinf=1e4, neginf=-1e4)
+            arrays = [_to_numpy(item) for item in preds]
+            if len(arrays) < 3:
+                raise ValueError("Predictions tuple must contain at least three arrays")
+            logits_super = arrays[0]
+            logits_cat_pred = arrays[1]
+            logits_cat_gold = arrays[2]
+            prop_presence_logits = arrays[3] if len(arrays) > 3 else None
+            prop_regression = arrays[4] if len(arrays) > 4 else None
+        else:
+            logits = _to_numpy(preds)
+            if logits is None:
+                raise ValueError("Predictions are empty")
+            if logits.ndim != 2 or logits.shape[1] != num_super + 2 * num_cat:
+                raise ValueError(f"atteso (N, {num_super + 2 * num_cat}), trovato {logits.shape}")
+            logits_super = logits[:, :num_super]
+            logits_cat_pred = logits[:, num_super : num_super + num_cat]
+            logits_cat_gold = logits[:, num_super + num_cat : num_super + 2 * num_cat]
+            prop_presence_logits = None
+            prop_regression = None
+
+        logits_super = np.nan_to_num(logits_super, nan=0.0, posinf=1e4, neginf=-1e4)
+        logits_cat_pred = np.nan_to_num(logits_cat_pred, nan=0.0, posinf=1e4, neginf=-1e4)
+        logits_cat_gold = np.nan_to_num(logits_cat_gold, nan=0.0, posinf=1e4, neginf=-1e4)
 
         if isinstance(labels, dict):
             y_super = np.asarray(labels["super_labels"])
@@ -31,15 +57,6 @@ def make_compute_metrics(num_super: int, num_cat: int):
             if arr.ndim != 2 or arr.shape[1] < 2:
                 raise ValueError(f"Label IDs formato inatteso: {arr.shape}")
             y_super, y_cat = arr[:, 0], arr[:, 1]
-
-        S = num_super
-        C = num_cat
-        if logits.shape[1] != S + 2 * C:
-            raise ValueError(f"atteso (N, {S + 2 * C}), trovato {logits.shape}")
-
-        logits_super = logits[:, :S]
-        logits_cat_pred = logits[:, S : S + C]
-        logits_cat_gold = logits[:, S + C : S + 2 * C]
 
         pred_super = logits_super.argmax(-1)
         pred_cat_pred_super = logits_cat_pred.argmax(-1)
@@ -58,6 +75,66 @@ def make_compute_metrics(num_super: int, num_cat: int):
             if mask.any()
             else float("nan"),
         }
+
+        if property_meta is not None and getattr(property_meta, "has_properties", lambda: False)():
+            slot_mask = None
+            presence_labels = None
+            regression_targets = None
+            regression_mask = None
+            if isinstance(labels, dict):
+                slot_mask = labels.get("property_slot_mask")
+                presence_labels = labels.get("property_presence_labels")
+                regression_targets = labels.get("property_regression_targets")
+                regression_mask = labels.get("property_regression_mask")
+
+            if (
+                prop_presence_logits is not None
+                and presence_labels is not None
+                and slot_mask is not None
+            ):
+                slot_mask_np = np.asarray(slot_mask, dtype=np.float32)
+                if slot_mask_np.ndim == 1:
+                    slot_mask_np = slot_mask_np[:, None]
+                slot_mask_np = slot_mask_np > 0.5
+
+                presence_true = np.asarray(presence_labels, dtype=np.float32)
+                if presence_true.ndim == 1:
+                    presence_true = presence_true[:, None]
+                presence_true = presence_true > 0.5
+
+                probs = np.asarray(prop_presence_logits, dtype=np.float32)
+                if probs.ndim == 1:
+                    probs = probs[:, None]
+                probs = 1.0 / (1.0 + np.exp(-probs))
+                preds_presence = probs >= 0.5
+                valid = slot_mask_np.reshape(slot_mask_np.shape[0], -1)
+                if valid.any():
+                    y_true = presence_true[valid]
+                    y_pred = preds_presence[valid]
+                    if y_true.size:
+                        metrics["prop_presence_accuracy"] = accuracy_score(y_true, y_pred)
+                        metrics["prop_presence_f1"] = f1_score(y_true, y_pred, average="binary")
+
+            if (
+                prop_regression is not None
+                and regression_targets is not None
+                and regression_mask is not None
+            ):
+                reg_mask_np = np.asarray(regression_mask, dtype=np.float32)
+                if reg_mask_np.ndim == 1:
+                    reg_mask_np = reg_mask_np[:, None]
+                reg_mask_np = reg_mask_np > 0.5
+                if reg_mask_np.any():
+                    preds_reg = np.asarray(prop_regression, dtype=np.float32)
+                    if preds_reg.ndim == 1:
+                        preds_reg = preds_reg[:, None]
+                    target_reg = np.asarray(regression_targets, dtype=np.float32)
+                    if target_reg.ndim == 1:
+                        target_reg = target_reg[:, None]
+                    diff = preds_reg[reg_mask_np] - target_reg[reg_mask_np]
+                    if diff.size:
+                        metrics["prop_reg_rmse"] = float(np.sqrt(np.mean(diff**2)))
+                        metrics["prop_reg_mae"] = float(np.mean(np.abs(diff)))
         return metrics
 
     return _compute


### PR DESCRIPTION
## Summary
- keep property metadata in label and hierarchical training datasets and convert them into multi-task targets
- add property prediction heads to both classifiers, update losses, and persist property configuration in exports
- extend metrics reporting and CLI docs to cover property tasks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1cc7ca0948322af4c7a141bb77c52