### PR TITLE
Restrict property extraction to predicted category slots

### DIFF
--- a/src/robimb/inference/pipeline.py
+++ b/src/robimb/inference/pipeline.py
@@ -1,20 +1,103 @@
 
 from __future__ import annotations
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Iterable, Optional, Sequence, Set
 import json, os
-from ..core.pack_loader import load_pack
 from ..inference.predict_category import load_classifier, predict_topk, _load_id2label
 from ..inference.calibration import TemperatureCalibrator
 from ..features.extractors import extract_properties
 from ..validators.engine import validate
 from ..templates.render import render
 
-def _find_cat_entry(pack, cat_label: str):
+def find_cat_entry(pack, cat_label: str):
     # look into catmap mappings
     for m in pack.catmap.get("mappings", []):
         if m.get("cat_label","").lower() == (cat_label or "").lower():
             return m
     return None
+
+
+def _extractor_property_ids(pack) -> Set[str]:
+    cache = getattr(pack, "_extractor_property_ids", None)
+    if cache is None:
+        cache = {
+            item.get("property_id")
+            for item in pack.extractors.get("patterns", [])
+            if item.get("property_id")
+        }
+        setattr(pack, "_extractor_property_ids", cache)
+    return cache
+
+
+def _category_property_index(pack) -> Dict[str, Set[str]]:
+    cache = getattr(pack, "_category_property_index", None)
+    if cache is not None:
+        return cache
+
+    index: Dict[str, Set[str]] = {}
+    groups = pack.registry.get("groups", {}) if getattr(pack, "registry", None) else {}
+
+    def collect_from_groups(group_ids: Iterable[str]) -> Set[str]:
+        props: Set[str] = set()
+        for gid in group_ids or []:
+            group = groups.get(gid)
+            if group:
+                props.update(group.get("properties", []))
+        return props
+
+    for mapping in pack.catmap.get("mappings", []):
+        allowed: Set[str] = set()
+        for key in ("props_required", "props_recommended"):
+            allowed.update(mapping.get(key, []))
+        allowed.update(collect_from_groups(mapping.get("groups_required", [])))
+        allowed.update(collect_from_groups(mapping.get("groups_recommended", [])))
+        for target in mapping.get("keynote_mapping", {}).values():
+            if isinstance(target, str) and target:
+                allowed.add(target)
+
+        cat_label = str(mapping.get("cat_label", "")).lower()
+        cat_id = str(mapping.get("cat_id", "")).lower()
+        frozen = set(allowed)
+        if cat_label:
+            index[cat_label] = frozen
+        if cat_id:
+            index[cat_id] = frozen
+
+    setattr(pack, "_category_property_index", index)
+    return index
+
+
+def _normalize_category_labels(category: Any) -> Sequence[str]:
+    if category is None:
+        return []
+    if isinstance(category, str):
+        return [category]
+    if isinstance(category, dict):
+        val = category.get("label")
+        return [val] if val else []
+    labels: list[str] = []
+    try:
+        iterator = iter(category)
+    except TypeError:
+        return labels
+    for item in iterator:
+        labels.extend(_normalize_category_labels(item))
+    return labels
+
+
+def predict_properties(text: str, pack, categories: Any) -> Dict[str, Any]:
+    labels = {lbl.strip() for lbl in _normalize_category_labels(categories) if lbl}
+    allowed_properties: Optional[Set[str]] = None
+    if labels:
+        index = _category_property_index(pack)
+        extractor_ids = _extractor_property_ids(pack)
+        collected: Set[str] = set()
+        for label in labels:
+            key = label.lower()
+            collected.update(index.get(key, set()))
+        collected.intersection_update(extractor_ids)
+        if collected:
+            allowed_properties = collected
+    return extract_properties(text, pack.extractors, allowed_properties=allowed_properties)
 
 def run_pipeline(text: str, pack, model_name_or_path: str, label_index_path: str, topk: int = 5, calibrator_path: Optional[str]=None) -> Dict[str, Any]:
     id2label = _load_id2label(label_index_path)
@@ -29,10 +112,10 @@ def run_pipeline(text: str, pack, model_name_or_path: str, label_index_path: str
     top, topk_list, probs, logits = predict_topk(text, model, tokenizer, id2label, topk=topk, calibrator=calibrator)
 
     # 2) Properties (regex extractors from pack)
-    props = extract_properties(text, pack.extractors)
+    props = predict_properties(text, pack, top["label"])
 
     # 3) Validation (rules from pack), pass cat entry to rules if needed
-    cat_entry = _find_cat_entry(pack, top["label"])
+    cat_entry = find_cat_entry(pack, top["label"])
     issues = validate(top["label"], props, context={}, rules_pack=pack.validators, cat_entry=cat_entry)
 
     # 4) Description render (templates from pack)

--- a/tests/test_service_smoke.py
+++ b/tests/test_service_smoke.py
@@ -2,3 +2,71 @@
 def test_import_app():
     from robimb.service.app import app
     assert app is not None
+
+
+def test_predict_filters_properties(monkeypatch):
+    from robimb.service.app import PredictIn, predict
+
+    class DummyPack:
+        def __init__(self):
+            self.extractors = {
+                "patterns": [
+                    {"property_id": "grpA.alpha", "regex": [r"\balpha\b"], "normalizers": []},
+                    {"property_id": "grpB.beta", "regex": [r"\bbeta\b"], "normalizers": []},
+                ]
+            }
+            self.registry = {
+                "groups": {
+                    "grpA": {"properties": ["grpA.alpha"]},
+                    "grpB": {"properties": ["grpB.beta"]},
+                }
+            }
+            self.catmap = {
+                "mappings": [
+                    {
+                        "cat_id": "cat.a",
+                        "cat_label": "Categoria A",
+                        "groups_required": ["grpA"],
+                        "groups_recommended": [],
+                        "props_required": [],
+                        "props_recommended": [],
+                        "keynote_mapping": {},
+                    },
+                    {
+                        "cat_id": "cat.b",
+                        "cat_label": "Categoria B",
+                        "groups_required": ["grpB"],
+                        "groups_recommended": [],
+                        "props_required": [],
+                        "props_recommended": [],
+                        "keynote_mapping": {},
+                    },
+                ]
+            }
+            self.validators = {"rules": []}
+            self.templates = {"templates": []}
+
+    dummy_pack = DummyPack()
+
+    def fake_load_pack(path):
+        return dummy_pack
+
+    def fake_load_model(model_path, label_index_path, calibrator_path=None):
+        return object(), object(), {0: "Categoria A", 1: "Categoria B"}, None
+
+    def fake_predict_topk(text, model, tokenizer, id2label, topk=5, calibrator=None):
+        results = [
+            {"id": 0, "label": "Categoria A", "score": 0.9},
+            {"id": 1, "label": "Categoria B", "score": 0.1},
+        ]
+        return results[0], results, [0.9, 0.1], [0.9, 0.1]
+
+    monkeypatch.setattr("robimb.service.app._load_pack_once", fake_load_pack)
+    monkeypatch.setattr("robimb.service.app._load_model_once", fake_load_model)
+    monkeypatch.setattr("robimb.inference.predict_category.predict_topk", fake_predict_topk)
+
+    payload = PredictIn(text="alpha beta", topk=2)
+    response = predict(payload)
+    assert response.category["label"] == "Categoria A"
+    assert "grpA.alpha" in response.properties
+    assert "grpB.beta" not in response.properties


### PR DESCRIPTION
## Summary
- add optional filtering to the regex extractor so only category-allowed properties are evaluated
- build a category-to-property index in the inference pipeline and reuse the new `predict_properties` helper in both the CLI pipeline and FastAPI service
- extend the service smoke tests with a stubbed scenario that asserts only slots for the predicted category are returned

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1cc8a66f883228911c984a72cd0a2