### PR TITLE
Expose shared property prediction logic

### DIFF
--- a/src/robimb/inference/pipeline.py
+++ b/src/robimb/inference/pipeline.py
@@ -1,12 +1,12 @@
 
 from __future__ import annotations
-from typing import Dict, Any, Iterable, Optional, Sequence, Set
+from typing import Dict, Any, Optional
 import json, os
 from ..inference.predict_category import load_classifier, predict_topk, _load_id2label
 from ..inference.calibration import TemperatureCalibrator
-from ..features.extractors import extract_properties
 from ..validators.engine import validate
 from ..templates.render import render
+from . import predict_properties as _properties_module
 
 def find_cat_entry(pack, cat_label: str):
     # look into catmap mappings
@@ -16,88 +16,8 @@ def find_cat_entry(pack, cat_label: str):
     return None
 
 
-def _extractor_property_ids(pack) -> Set[str]:
-    cache = getattr(pack, "_extractor_property_ids", None)
-    if cache is None:
-        cache = {
-            item.get("property_id")
-            for item in pack.extractors.get("patterns", [])
-            if item.get("property_id")
-        }
-        setattr(pack, "_extractor_property_ids", cache)
-    return cache
-
-
-def _category_property_index(pack) -> Dict[str, Set[str]]:
-    cache = getattr(pack, "_category_property_index", None)
-    if cache is not None:
-        return cache
-
-    index: Dict[str, Set[str]] = {}
-    groups = pack.registry.get("groups", {}) if getattr(pack, "registry", None) else {}
-
-    def collect_from_groups(group_ids: Iterable[str]) -> Set[str]:
-        props: Set[str] = set()
-        for gid in group_ids or []:
-            group = groups.get(gid)
-            if group:
-                props.update(group.get("properties", []))
-        return props
-
-    for mapping in pack.catmap.get("mappings", []):
-        allowed: Set[str] = set()
-        for key in ("props_required", "props_recommended"):
-            allowed.update(mapping.get(key, []))
-        allowed.update(collect_from_groups(mapping.get("groups_required", [])))
-        allowed.update(collect_from_groups(mapping.get("groups_recommended", [])))
-        for target in mapping.get("keynote_mapping", {}).values():
-            if isinstance(target, str) and target:
-                allowed.add(target)
-
-        cat_label = str(mapping.get("cat_label", "")).lower()
-        cat_id = str(mapping.get("cat_id", "")).lower()
-        frozen = set(allowed)
-        if cat_label:
-            index[cat_label] = frozen
-        if cat_id:
-            index[cat_id] = frozen
-
-    setattr(pack, "_category_property_index", index)
-    return index
-
-
-def _normalize_category_labels(category: Any) -> Sequence[str]:
-    if category is None:
-        return []
-    if isinstance(category, str):
-        return [category]
-    if isinstance(category, dict):
-        val = category.get("label")
-        return [val] if val else []
-    labels: list[str] = []
-    try:
-        iterator = iter(category)
-    except TypeError:
-        return labels
-    for item in iterator:
-        labels.extend(_normalize_category_labels(item))
-    return labels
-
-
 def predict_properties(text: str, pack, categories: Any) -> Dict[str, Any]:
-    labels = {lbl.strip() for lbl in _normalize_category_labels(categories) if lbl}
-    allowed_properties: Optional[Set[str]] = None
-    if labels:
-        index = _category_property_index(pack)
-        extractor_ids = _extractor_property_ids(pack)
-        collected: Set[str] = set()
-        for label in labels:
-            key = label.lower()
-            collected.update(index.get(key, set()))
-        collected.intersection_update(extractor_ids)
-        if collected:
-            allowed_properties = collected
-    return extract_properties(text, pack.extractors, allowed_properties=allowed_properties)
+    return _properties_module.predict_properties(text, pack, categories)
 
 def run_pipeline(text: str, pack, model_name_or_path: str, label_index_path: str, topk: int = 5, calibrator_path: Optional[str]=None) -> Dict[str, Any]:
     id2label = _load_id2label(label_index_path)

--- a/src/robimb/inference/predict_properties.py
+++ b/src/robimb/inference/predict_properties.py
@@ -1,1 +1,115 @@
-def predict_properties(text:str, extractors:dict): return {}
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional, Sequence, Set
+
+from ..features.extractors import extract_properties
+
+
+def _normalize_category_labels(category: Any) -> Sequence[str]:
+    """Return a flat list of category labels from various inputs."""
+
+    if category is None:
+        return []
+    if isinstance(category, str):
+        return [category]
+    if isinstance(category, dict):
+        value = category.get("label")
+        return [value] if value else []
+
+    labels: list[str] = []
+    try:
+        iterator = iter(category)
+    except TypeError:
+        return labels
+
+    for item in iterator:
+        labels.extend(_normalize_category_labels(item))
+    return labels
+
+
+def _extractor_property_ids(pack) -> Set[str]:
+    """Return the set of property ids defined in the extractors pack."""
+
+    cache = getattr(pack, "_extractor_property_ids", None)
+    if cache is None:
+        cache = {
+            item.get("property_id")
+            for item in pack.extractors.get("patterns", [])
+            if item.get("property_id")
+        }
+        setattr(pack, "_extractor_property_ids", cache)
+    return cache
+
+
+def _category_property_index(pack) -> Dict[str, Set[str]]:
+    """Build an index mapping category identifiers to allowed property ids."""
+
+    cache = getattr(pack, "_category_property_index", None)
+    if cache is not None:
+        return cache
+
+    index: Dict[str, Set[str]] = {}
+    groups = pack.registry.get("groups", {}) if getattr(pack, "registry", None) else {}
+
+    def collect_from_groups(group_ids: Iterable[str]) -> Set[str]:
+        props: Set[str] = set()
+        for gid in group_ids or []:
+            group = groups.get(gid)
+            if group:
+                props.update(group.get("properties", []))
+        return props
+
+    for mapping in pack.catmap.get("mappings", []):
+        allowed: Set[str] = set()
+        for key in ("props_required", "props_recommended"):
+            allowed.update(mapping.get(key, []))
+        allowed.update(collect_from_groups(mapping.get("groups_required", [])))
+        allowed.update(collect_from_groups(mapping.get("groups_recommended", [])))
+        for target in mapping.get("keynote_mapping", {}).values():
+            if isinstance(target, str) and target:
+                allowed.add(target)
+
+        cat_label = str(mapping.get("cat_label", "")).lower()
+        cat_id = str(mapping.get("cat_id", "")).lower()
+        frozen = set(allowed)
+        if cat_label:
+            index[cat_label] = frozen
+        if cat_id:
+            index[cat_id] = frozen
+
+    setattr(pack, "_category_property_index", index)
+    return index
+
+
+def predict_properties(text: str, pack, categories: Any) -> Dict[str, Any]:
+    """
+    Extract properties from ``text`` limited to those allowed for ``categories``.
+
+    ``categories`` can be expressed as a string, dict, iterable or nested
+    combination of the previous forms. Only the properties whose identifiers are
+    both declared in the extractors pack and allowed by the category mappings
+    are returned.
+    """
+
+    labels = {label.strip() for label in _normalize_category_labels(categories) if label}
+    allowed_properties: Optional[Set[str]] = None
+    if labels:
+        index = _category_property_index(pack)
+        extractor_ids = _extractor_property_ids(pack)
+        collected: Set[str] = set()
+        for label in labels:
+            key = label.lower()
+            collected.update(index.get(key, set()))
+        collected.intersection_update(extractor_ids)
+        if collected:
+            allowed_properties = collected
+
+    return extract_properties(text, pack.extractors, allowed_properties=allowed_properties)
+
+
+__all__ = [
+    "predict_properties",
+    "_normalize_category_labels",
+    "_extractor_property_ids",
+    "_category_property_index",
+]

--- a/tests/test_predict_properties.py
+++ b/tests/test_predict_properties.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+from robimb.inference.predict_properties import predict_properties
+
+
+def _make_pack():
+    return SimpleNamespace(
+        catmap={
+            "mappings": [
+                {
+                    "cat_label": "Roof",
+                    "props_required": ["roof_color"],
+                    "props_recommended": [],
+                    "groups_required": [],
+                    "groups_recommended": [],
+                    "keynote_mapping": {},
+                }
+            ]
+        },
+        registry={"groups": {}},
+        extractors={
+            "patterns": [
+                {"property_id": "roof_color", "regex": [r"roof color (\w+)"]},
+                {"property_id": "wall_color", "regex": [r"wall color (\w+)"]},
+            ]
+        },
+    )
+
+
+def test_predict_properties_filters_by_category():
+    pack = _make_pack()
+    text = "roof color red and wall color blue"
+
+    props = predict_properties(text, pack, "Roof")
+
+    assert props == {"roof_color": "red"}


### PR DESCRIPTION
## Summary
- expose a public `predict_properties` helper that encapsulates property filtering logic
- make the inference pipeline reuse the shared helper instead of its own copy
- add a unit test covering category-based property filtering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1d409816083229bc06fe3c0d9b852