### PR TITLE
Add documentation suite for robimb modules

### DIFF
--- a/docs/cli_convert.md
+++ b/docs/cli_convert.md
@@ -1,0 +1,7 @@
+# Comando `robimb convert`
+
+Il comando `convert` definito in `cli/main.py` esegue la preparazione dei dataset a partire dai file JSONL grezzi. Gli argomenti principali includono `--train-file` e `--val-file` per i sorgenti, `--ontology` per l'ontologia opzionale, `--label-maps` e `--out-dir` per le destinazioni degli artefatti. In assenza di un file di validazione viene effettuato uno split automatico controllato da `--val-split` e `--random-state`.
+
+Opzioni aggiuntive permettono di generare un corpus TAPT (`--make-mlm-corpus`, `--mlm-output`, `--extra-mlm`), di produrre grafici e statistiche (`--reports-dir`) e di integrare la pipeline di estrazione proprietà tramite `--properties-registry` e `--extractors-pack`. Il flag `--done-uids` consente di escludere elementi già etichettati.
+
+Internamente il comando costruisce una `ConversionConfig` (modulo `cli/convert.py`) e invoca `run_conversion`, che restituisce percorsi agli artefatti salvati (`train_processed.jsonl`, `val_processed.jsonl`, `mask_matrix.npy`, `mask_report.json`, label map). Il risultato viene serializzato in JSON su stdout, favorendo l'integrazione con pipeline automatiche.

--- a/docs/cli_pack_merge.md
+++ b/docs/cli_pack_merge.md
@@ -1,0 +1,5 @@
+# Comando `robimb pack-merge`
+
+Il comando `pack-merge` unifica knowledge pack legacy e versioni di produzione in un bundle coerente. Gli argomenti principali sono `--data-dir` (contenitore dei JSON storici), `--out-dir` (destinazione del pack versionato), `--version` (stringa semantica) e `--current-dir` (cartella in cui scrivere il symlink/log `pack.json`). Il flag `--update-current/--no-update-current` controlla se aggiornare automaticamente il pack corrente dopo la fusione.
+
+Sotto il cofano viene richiamata la funzione `data.build_merged_pack`, che restituisce un oggetto con la lista di file generati e metadati di generazione. Se richiesto, `data.write_pack_index` produce un indice compatibile con il servizio FastAPI. Il comando stampa un riepilogo JSON con percorso dei file e manifest, utile per tracciare versioni e automatizzare deploy.

--- a/docs/cli_train.md
+++ b/docs/cli_train.md
@@ -1,0 +1,5 @@
+# Comando `robimb train`
+
+Il gruppo di comandi `train` in `cli/main.py` funge da proxy verso gli script di addestramento specializzati. Typer definisce due sottocomandi: `robimb train label` e `robimb train hier`. Entrambi inoltrano gli argomenti direttamente a `cli/train.py`, che a sua volta richiama le funzioni `training.label_trainer.main` o `training.hier_trainer.main` basate su `argparse`.
+
+Questo design preserva la CLI avanzata originale (inclusi file di configurazione, override da terminale e pubblicazione su Hub) evitando duplicazioni di logica. Se non vengono forniti argomenti, ciascun sottocomando mostra l'help dettagliato generato da `argparse`, mentre eventuali errori vengono convertiti in `typer.Exit` per mantenere il comportamento coerente con gli altri comandi Typer.

--- a/docs/cli_validate.md
+++ b/docs/cli_validate.md
@@ -1,0 +1,5 @@
+# Comando `robimb validate`
+
+Il comando `validate` consente di valutare un modello esportato su un dataset etichettato. Richiede percorsi espliciti a `--model-dir`, `--test-file`, `--label-maps` e, facoltativamente, a `--ontology`. Parametri aggiuntivi controllano `batch-size`, `max-length` del tokenizer, la destinazione del file di metriche (`--output`) e la serializzazione delle predizioni (`--predictions`).
+
+L'implementazione crea un oggetto `ValidationConfig` (`cli/validate.py`) e invoca `validate_model`, che carica il modello tramite gli helper di inferenza, calcola metriche standard (precision, recall, F1 macro/micro) e genera report opzionali con matrici di confusione (`--report-dir`). Se `--output` non è specificato, le metriche vengono stampate su stdout in JSON, facilitando l'utilizzo in pipeline CI.

--- a/docs/core_knowledge_pack.md
+++ b/docs/core_knowledge_pack.md
@@ -1,0 +1,7 @@
+# Gestione del knowledge pack
+
+I moduli sotto `core/` definiscono i contratti e le utility per i knowledge pack. `pack_loader.py` dichiara il dataclass `KnowledgePack` (registry, catmap, templates, validators, ecc.) e la funzione `load_pack`, che legge `pack.json`, risolve i percorsi relativi e carica in memoria i singoli componenti JSON.
+
+`pack_tools.py` fornisce funzioni di supporto per costruire manifest e aggiornare il pack corrente. `build_manifest` copia i file chiave in una directory di destinazione, calcola hash SHA-256 e scrive `manifest.json` con metadati (dimensioni, digest, timestamp). `update_current` genera `pack/current/pack.json` puntando alla versione appena creata tramite percorsi relativi.
+
+Infine `pack_merge.py` e `pack_validate.py` (non trattati in dettaglio qui) orchestrano rispettivamente la fusione di pack legacy e la validazione degli schemi. Queste routine sono richiamate dal comando `robimb pack-merge` e assicurano che il servizio e la CLI lavorino sempre con un bundle coerente e tracciabile.

--- a/docs/dataset_preparation.md
+++ b/docs/dataset_preparation.md
@@ -1,0 +1,7 @@
+# Pipeline di preparazione dei dataset
+
+Il comando `robimb convert` delega la logica di preprocessing al modulo `utils/data_utils.py`, che fornisce funzioni per leggere i JSONL grezzi, applicare la mappatura delle etichette e arricchire i record con proprietà estratte automaticamente. La funzione `load_jsonl_to_df` converte i file `train_classif.jsonl` e `val_classif.jsonl` in `DataFrame` Pandas pronti per l'elaborazione.
+
+La funzione `prepare_classification_dataset` è responsabile della maggior parte del lavoro: crea o carica le label map (`create_or_load_label_maps`), risolve gli indici numerici `super_label` e `cat_label`, filtra i record non mappabili e associa a ciascun elemento la struttura di proprietà definita nel registry (`properties_registry_extended.json`). Se disponibile, un pacchetto di estrattori (`extractors_patterns.json`) viene passato a `features.extractors.extract_properties` per popolare automaticamente i valori di proprietà partendo dal testo grezzo.
+
+Durante la preparazione vengono considerate esclusioni opzionali tramite `done_uids.txt`, viene calcolato lo split train/val deterministico e vengono restituiti `DataFrame` arricchiti con le colonne `property_schema` e `properties`. Questi dataset vengono poi serializzati con `save_datasets`, che scrive JSONL preprocessati (`train_processed.jsonl`, `val_processed.jsonl`) e i report di supporto. La stessa pipeline può generare un corpus per TAPT tramite `prepare_mlm_corpus`, concatenando le descrizioni testuali e le label description quando richiesto.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+# Documentazione di progetto
+
+Questa cartella raccoglie una serie di note operative e di design pensate per accompagnare lo sviluppo del toolkit **robimb**. Ogni pagina approfondisce un ambito specifico del codice, dai comandi CLI ai componenti di training e inferenza. La mappa seguente elenca gli argomenti disponibili:
+
+- [Panoramica architetturale](overview.md)
+- [Pipeline di preparazione dei dataset](dataset_preparation.md)
+- [Gestione delle label map](label_maps.md)
+- [Maschera ontologica e report diagnostici](ontology_masks.md)
+- [Estrazione proprietà testuali](property_extraction.md)
+- [Modello a label embedding](label_model.md)
+- [Classificatore gerarchico multi-task](masked_model.md)
+- [Training del label model](training_label_model.md)
+- [Training del modello gerarchico](training_hier_model.md)
+- [Pre-training TAPT/MLM](training_tapt.md)
+- [Comando `convert`](cli_convert.md)
+- [Comando `train`](cli_train.md)
+- [Comando `validate`](cli_validate.md)
+- [Comando `pack-merge`](cli_pack_merge.md)
+- [Pipeline di inferenza end-to-end](inference_pipeline.md)
+- [Servizio FastAPI](service_api.md)
+- [Gestione del knowledge pack](core_knowledge_pack.md)
+- [Utility per i dati](utils_data.md)
+- [Utility per le metriche](utils_metrics.md)
+- [Reportistica e analisi](reporting.md)
+
+Le pagine sono pensate per essere lette in modo indipendente; ogni documento fornisce collegamenti al codice di riferimento e suggerimenti per estensioni future.

--- a/docs/inference_pipeline.md
+++ b/docs/inference_pipeline.md
@@ -1,0 +1,5 @@
+# Pipeline di inferenza end-to-end
+
+`inference/pipeline.py` coordina tutti i passaggi necessari per passare da una descrizione testuale a una scheda arricchita. La funzione `run_pipeline` accetta il testo, il knowledge pack già caricato, il percorso del modello e della label index, oltre a un opzionale calibratore di temperatura. Vengono caricati tokenizer e modello tramite `predict_category.load_classifier`, mentre `_load_id2label` recupera la corrispondenza indice→etichetta.
+
+La pipeline esegue nell'ordine: classificazione top-k (`predict_topk`), estrazione proprietà (`predict_properties` basata sul pack), validazione regole (`validators.engine.validate`) e rendering descrittivo (`templates.render`). Se è disponibile un calibratore salvato su disco viene ricostruito con `TemperatureCalibrator.from_state_dict` per migliorare la calibrazione delle probabilità. Il risultato finale è un dizionario JSON-friendly con categoria scelta, lista top-k, proprietà estratte, eventuali issue e descrizione generata.

--- a/docs/label_maps.md
+++ b/docs/label_maps.md
@@ -1,0 +1,7 @@
+# Gestione delle label map
+
+Le label map definiscono la corrispondenza bidirezionale tra gli identificativi stringa di classi `super` e `cat` e gli interi utilizzati durante l'addestramento. La funzione `utils.data_utils.create_or_load_label_maps` incapsula il flusso: se il file JSON esiste viene letto tramite `utils.ontology_utils.load_label_maps`, altrimenti viene generato sfruttando l'ontologia (`ontology.json`).
+
+Il file risultante contiene quattro mappe (`super2id`, `cat2id`, `id2super`, `id2cat`) e viene riutilizzato da tutto il codice. I trainer (`training/label_trainer.py` e `training/hier_trainer.py`) lo caricano per determinare `num_super`, `num_cat` e l'ID associato alla classe di fallback `#N/D`. Anche la pipeline di inferenza (`inference.predict_category._load_id2label`) lo usa per riconciliare gli indici restituiti dai modelli con le etichette leggibili.
+
+La consistenza tra label map e ontologia è garantita dalla funzione `utils.ontology_utils.build_mask_from_ontology`, che produce anche un report diagnostico con conteggio di nodi mancanti. Qualsiasi modifica alle classi deve quindi essere riflessa in `label_maps.json` per evitare mismatch durante la validazione dei dataset e l'esecuzione dei modelli.

--- a/docs/label_model.md
+++ b/docs/label_model.md
@@ -1,0 +1,7 @@
+# Modello a label embedding
+
+`models/label_model.py` definisce `LabelEmbedModel`, un classificatore che proietta testi e label nello stesso spazio vettoriale. Il backbone è un encoder Hugging Face caricato con `AutoModel.from_pretrained`, seguito da un blocco di mean pooling (`MeanPool`) e da una testa MLP (`EmbHead`) che produce embedding normalizzati opzionalmente via L2.
+
+Le rappresentazioni delle classi vengono inizializzate codificando i testi descrittivi (`_encode_label_texts`) e possono essere congelate o rese addestrabili (`train_label_emb`). Durante la forward vengono calcolati logit super e cat sfruttando il prodotto scalare tra embedding del documento e prototipi, scalato da un parametro `logit_scale` trainabile. Il modello supporta una `mask_matrix` derivata dall'ontologia per inibire combinazioni super→cat non valide e gestisce un ID `#N/D` con l'opzione `ban_nd_in_eval`.
+
+Oltre alla classificazione, `LabelEmbedModel` include due teste opzionali per le proprietà: `property_presence_head` (classificazione multi-label) e `property_regression_head` (regressione), controllate da mask `property_cat_mask` e `property_numeric_mask`. Le perdite sono pesate tramite `property_presence_weight` e `property_regression_weight`, consentendo di bilanciare l'obiettivo principale con le attività ausiliarie.

--- a/docs/masked_model.md
+++ b/docs/masked_model.md
@@ -1,0 +1,7 @@
+# Classificatore gerarchico multi-task
+
+Il file `models/masked_model.py` implementa `MultiTaskBERTMasked`, un modello che combina classificazione gerarchica e predizione di proprietà. Analogamente al label model, utilizza un encoder Transformer condiviso, una fase di mean pooling (`MeanPool`) e una testa `EmbHead` con normalizzazione opzionale. Le predizioni sui nodi `super` e `cat` sono generate da teste ArcFace (`ArcMarginProduct`) che applicano margini angolari per incrementare la separazione tra classi; in alternativa possono essere sostituite da layer lineari standard.
+
+Il costruttore richiede una matrice di maschera super→cat già validata, l'identificativo `#N/D`, e parametri per controllare label smoothing, normalizzazione e ritorno concatenato dei logit. Come per il label model sono previste teste ausiliarie per presenza e regressione delle proprietà, abilitate quando `num_properties > 0` e accompagnate da mask che limitano gli slot rilevanti per categoria.
+
+Durante la forward il modello applica la maschera sulle logit di categoria, garantendo che i punteggi non validi vengano impostati a valori molto negativi (`_very_neg_like`). Questa architettura è adatta a scenari in cui si desidera ottimizzare simultaneamente la classificazione gerarchica e l'estrazione di attributi strutturati.

--- a/docs/ontology_masks.md
+++ b/docs/ontology_masks.md
@@ -1,0 +1,7 @@
+# Maschera ontologica e report diagnostici
+
+La maschera ontologica è una matrice S×C che impone vincoli tra classi `super` e `cat`. Viene costruita da `utils.data_utils.build_mask_and_report`, che a sua volta richiama `utils.ontology_utils.build_mask_from_ontology` quando è disponibile un file `ontology.json`. In assenza di ontologia, la funzione crea una matrice piena di `1.0` e registra nel report la nota *"no ontology provided"* per segnalare l'assenza di vincoli.
+
+Quando l'ontologia è presente, il report restituito include il numero di super e categorie mancanti, oltre a statistiche di copertura utilizzate durante la conversione. Il trainer del label model (`training/label_trainer.py`) e quello gerarchico (`training/hier_trainer.py`) consumano la maschera per inizializzare `mask_matrix` e per generare maschere dinamiche in fase di inferenza (`LabelEmbedModel._build_pred_mask`). Una riga vuota nella maschera viene sanata forzando la possibilità di predire tutte le categorie, evitando errori di training.
+
+Il report (`mask_report.json`) viene salvato dal comando `convert` insieme ai dataset preprocessati. È uno strumento diagnostico utile per individuare eventuali disallineamenti tra l'ontologia fornita e le label map generate, oltre che per monitorare l'effetto di modifiche strutturali nelle gerarchie di dominio.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,9 @@
+# Panoramica architetturale
+
+Il pacchetto `robimb` espone un toolkit modulare per la classificazione di testi BIM basato su Transformer. Il namespace principale (`src/robimb/__init__.py`) organizza i sotto-moduli funzionali: CLI Typer, componenti core per i knowledge pack, modelli, pipeline di inferenza, servizio FastAPI, training e utility condivise. Questa organizzazione consente di installare il progetto come pacchetto Python e riutilizzarlo tanto da riga di comando quanto da codice.
+
+L'interazione principale avviene tramite l'applicazione Typer (`cli/main.py`), che funge da front-end per la conversione dei dati, l'addestramento dei modelli, la validazione e le operazioni sui knowledge pack. I moduli `models/label_model.py` e `models/masked_model.py` implementano rispettivamente il classificatore a label embedding e la variante gerarchica multi-task; entrambi sfruttano encoder Hugging Face pre-addestrati e supportano maschere ontologiche derivate dai file `ontology.json`.
+
+Le routine di training (`training/label_trainer.py`, `training/hier_trainer.py`, `training/tapt_mlm.py`) orchestrano `transformers.Trainer`, gestendo tokenizzazione, sampler, callback per sanificare i gradienti e pubblicazione su Hugging Face Hub. Le funzioni di utilità nelle cartelle `utils/` e `features/` coprono la preparazione dei dataset, la costruzione delle maschere ontologiche e l'estrazione automatica di proprietà tramite regex.
+
+Per l'esecuzione in produzione sono disponibili due percorsi: la pipeline di inferenza (`inference/pipeline.py`) che combina classificazione, estrazione proprietà, validazione e rendering descrittivo, e il servizio FastAPI (`service/app.py`) che esegue le stesse operazioni esponendo endpoint HTTP e gestendo la cache di modelli e knowledge pack. I componenti core (`core/pack_loader.py`, `core/pack_tools.py`) governano la lettura e la fusione dei pack legacy, mentre i template e i validator definiscono le regole di dominio.

--- a/docs/property_extraction.md
+++ b/docs/property_extraction.md
@@ -1,0 +1,7 @@
+# Estrazione proprietà testuali
+
+Il modulo `features/extractors.py` implementa un motore di estrazione basato su pattern regex configurabili. Ogni `Pattern` associa un `property_id` a una lista di espressioni regolari e a una sequenza di normalizzatori dichiarati nel pacchetto di estrattori (`extractors_pack`). I normalizzatori built-in spaziano da conversioni numeriche (`to_float`, `to_int`) a manipolazioni di stringa (`lower`, `strip`) e trasformazioni dominio-specifiche (`EI_from_any`, `normalize_foratura`).
+
+La funzione `_compile_patterns` filtra i pattern in base all'elenco di proprietà consentite e produce oggetti immutabili efficienti per la fase di matching. Durante l'estrazione (`extract_properties`) ogni regex viene applicata al testo, i match vengono normalizzati e aggregati secondo le regole definite; l'opzione `collect_many` consente di mantenere liste di valori anziché singoli campi.
+
+Le proprietà estratte vengono iniettate nella pipeline di conversione (`utils.data_utils.prepare_classification_dataset`) e successivamente sfruttate dai modelli durante l'addestramento multi-task per la previsione dei valori di proprietà. Questo approccio rende modulare l'aggiunta di nuovi schemi: è sufficiente aggiornare il pacchetto JSON di estrattori senza toccare il codice Python.

--- a/docs/reporting.md
+++ b/docs/reporting.md
@@ -1,0 +1,7 @@
+# Reportistica e analisi
+
+La cartella `reporting/` contiene utility per generare grafici e riepiloghi durante la conversione dei dataset e la valutazione dei modelli. `dataset_reports.py` produce statistiche descrittive (lunghezza media dei testi, distribuzioni di super/cat) e salva grafici PNG utilizzando Matplotlib/Seaborn in modalità headless (`matplotlib.use("Agg")`). I risultati vengono consolidati in `dataset_summary.json` e referenziati dal comando `convert` quando viene specificata l'opzione `--reports-dir`.
+
+`prediction_reports.py` si concentra invece sulle valutazioni: calcola confusion matrix normalizzate per le classi più frequenti, genera report testuali (`classification_report`) e identifica le coppie di classi più confuse. Anche in questo caso gli output sono grafici PNG e file JSON, pensati per essere consultati in fase di validazione (`robimb validate`).
+
+Questi strumenti aiutano a diagnosticare sbilanciamenti, individuare pattern di errore e documentare le performance dei modelli lungo il ciclo di vita.

--- a/docs/service_api.md
+++ b/docs/service_api.md
@@ -1,0 +1,7 @@
+# Servizio FastAPI
+
+Il modulo `service/app.py` espone un'API HTTP per integrare il modello in applicazioni esterne. Variabili d'ambiente configurano percorsi di default (`ROBIMB_PACK`, `ROBIMB_MODEL`, `ROBIMB_LABEL_INDEX`, `ROBIMB_CALIBRATOR`). Per evitare ricarichi ripetuti, il file mantiene uno stato condiviso `_state` protetto da lock (`_pack_lock`, `_model_lock`). Le funzioni `_load_pack_once` e `_load_model_once` caricano rispettivamente knowledge pack e modello solo quando cambia il percorso richiesto.
+
+L'applicazione definisce due endpoint principali: `GET /health`, che restituisce stato e percorsi configurati, e `POST /predict`, che riceve un payload `PredictIn` (testo, top-k desiderato, contesto opzionale, override percorsi). Il body viene validato con Pydantic e passato alle routine di inferenza: `predict_topk` per la classificazione, `predict_properties` per l'estrazione, `validators.engine.validate` per le regole e `templates.render` per la descrizione. L'output `PredictOut` riepiloga categoria, top-k, proprietà, issue e descrizione.
+
+Questo servizio riutilizza gli stessi helper della CLI garantendo coerenza dei risultati e permette override runtime (es. puntare a un knowledge pack temporaneo) senza riavviare il processo.

--- a/docs/training_hier_model.md
+++ b/docs/training_hier_model.md
@@ -1,0 +1,7 @@
+# Training del modello gerarchico
+
+`training/hier_trainer.py` replica la struttura del trainer a label embedding adattandola a `MultiTaskBERTMasked`. Il dataclass `HierTrainingArgs` copre iperparametri specifici come i coefficienti di ArcFace (`arcface_s`, `arcface_m`), il peso della loss di categoria (`lambda_cat`) e il `label_smoothing_super`. La pipeline prepara i dataset con `_build_dataset`, che gestisce tokenizzazione e tensori delle proprietà in modo coerente con il trainer precedente.
+
+Anche qui è disponibile l'opzione `balanced_sampler` per contrastare sbilanciamenti. Dopo aver caricato tokenizer e backbone, il trainer costruisce il modello passando la maschera ontologica e l'ID `#N/D`; le class weights possono essere derivate dai dataset per modulare la loss cross-entropy. Il `Trainer` di Hugging Face è configurato con scheduler selezionabile e callback `SanitizeGrads` per prevenire overflow numerici.
+
+Al termine dell'addestramento, il codice salva checkpoint completi (`pytorch_model.bin`, tokenizer) e produce un pacchetto `export/` con pesi in formato `safetensors`, label map e ontologia, replicando lo schema di deployment previsto per il label model.

--- a/docs/training_label_model.md
+++ b/docs/training_label_model.md
@@ -1,0 +1,7 @@
+# Training del label model
+
+`training/label_trainer.py` definisce `LabelTrainingArgs`, un dataclass che raccoglie tutte le opzioni CLI (checkpoint di partenza, file di training/validation, pesi di loss, pubblicazione su Hub). La funzione `train_label_model` gestisce il flusso: inizializza gli seed, crea la directory di output e carica le label map per determinare `num_super` e `num_cat`. Successivamente genera la maschera ontologica tramite `build_mask_and_report` e carica tokenizer e backbone indicati dagli argomenti.
+
+I dataset vengono costruiti con `_build_dataset`, che tokenizza i testi, allega gli indici numerici e prepara i tensori delle proprietà usando `build_property_targets`. Se `balanced_sampler` è attivo viene impiegato un `WeightedRandomSampler` basato sulla frequenza delle categorie. L'oggetto `LabelEmbedModel` può essere inizializzato da un checkpoint esistente (`init_from`) e supporta l'unfreezing progressivo degli ultimi layer tramite `unfreeze_last`.
+
+L'addestramento vero e proprio utilizza `transformers.Trainer` con `TrainingArguments` configurati dinamicamente (scheduler, warmup, gradient accumulation). Il callback `SanitizeGrads` monitora i gradienti NaN/Inf e li ripristina a zero per evitare instabilità. Al termine, il trainer salva i migliori pesi, esporta i prototipi delle label e, opzionalmente, pubblica l'artefatto sul modello indicato (`hub_repo`).

--- a/docs/training_tapt.md
+++ b/docs/training_tapt.md
@@ -1,0 +1,7 @@
+# Pre-training TAPT/MLM
+
+Lo script `training/tapt_mlm.py` fornisce un'interfaccia avanzata per il Domain-Adaptive Pre-Training (TAPT) con obiettivi di Masked Language Modeling. Sono supportate opzioni orientate alle GPU moderne: Whole-Word Masking (`--wwm`), Layer-wise Learning Rate Decay (`--llrd`), congelamento dei layer inferiori (`--freeze_layers`) e sblocco progressivo (`--unfreeze_at_epoch`). Il codice abilita automaticamente TF32 su GPU Ampere/Ada e consente l'uso di BF16, gradient checkpointing e resume robusto da checkpoint.
+
+Il flusso carica un dataset testuale tramite `datasets.load_dataset`, applica filtri di pulizia e deduplicazione (`load_text_files`), quindi segmenta il corpus in blocchi della dimensione desiderata con `prepare_mlm_blocks`. Tokenizer e modello (`AutoTokenizer`, `AutoModelForMaskedLM`) vengono istanziati in base ai parametri CLI, con supporto per collator specializzati (`DataCollatorForWholeWordMask`).
+
+Per l'ottimizzazione viene utilizzato `Trainer` di Hugging Face, arricchito da `EarlyStoppingCallback` e da utility personalizzate come `make_llrd_param_groups` per configurare AdamW con gruppi di parametri decrescenti. Il comando `robimb tapt` è un thin wrapper che passa gli argomenti Typer direttamente a questo script, garantendo uniformità con il resto della suite.

--- a/docs/utils_data.md
+++ b/docs/utils_data.md
@@ -1,0 +1,5 @@
+# Utility per i dati
+
+Il modulo `utils/data_utils.py` centralizza le funzioni di IO e trasformazione dati. Oltre alle routine descritte nella pipeline di conversione, include `save_datasets`, che serializza train/val preprocessati, label map e report della maschera ontologica; `prepare_mlm_corpus`, che concatena testi e descrizioni di label rimuovendo duplicati; e `build_mask_and_report`, che restituisce sia la matrice NumPy sia un dizionario con statistiche diagnostiche.
+
+`utils/io_utils.py` (non mostrato qui) contiene helper per scrivere file JSON/JSONL e per gestire directory temporanee. `utils/ontology_utils.py` fornisce la classe `Ontology`, funzioni per caricare l'ontologia, costruire la maschera e salvare le label map. Insieme, questi moduli creano un'infrastruttura riutilizzabile per tutte le pipeline del progetto, minimizzando la duplicazione di codice tra CLI, training e servizio.

--- a/docs/utils_metrics.md
+++ b/docs/utils_metrics.md
@@ -1,0 +1,5 @@
+# Utility per le metriche
+
+`utils/metrics_utils.py` espone `make_compute_metrics`, factory che restituisce una funzione compatibile con `transformers.Trainer`. La closure riceve le dimensioni di super e cat e opzionalmente metadati sulle proprietà. Durante la valutazione, la funzione gestisce sia il formato tuple (logit separati) sia matrici singole e converte i tensori in NumPy gestendo eventuali NaN/Inf.
+
+Le metriche calcolate includono accuracy e macro-F1 per le classi `super` e `cat`, distinguendo tra logit condizionati sulla predizione del super e logit condizionati sul super gold. Quando sono presenti teste di proprietà vengono calcolate anche accuracy/F1 per la presenza e MAE/RMSE per la regressione, utilizzando le maschere fornite nel batch (`property_slot_mask`, `property_regression_mask`). Questo approccio garantisce compatibilità con entrambe le architetture del progetto e fornisce segnali chiave per il monitoraggio delle performance multi-task.


### PR DESCRIPTION
## Summary
- add a documentation index that links to detailed pages for every major robimb subsystem
- describe the architecture, training flows, inference pipeline, CLI commands, and supporting utilities in dedicated Markdown files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d23c0318cc83229010184f1e8b8f82