### PR TITLE
Allow flexible spessore_lastra_mm extraction

### DIFF
--- a/data/properties_registry_extended.json
+++ b/data/properties_registry_extended.json
@@ -746,17 +746,16 @@
         ]
       },
       "spessore_lastra_mm": {
-        "type": "enum",
-        "values": [
-          10,
-          12.5,
-          15,
-          18,
-          "ignoto"
+        "type": "float",
+        "range": [
+          5,
+          200
         ],
+        "unknown": "ignoto",
         "normalizers": [
           "comma_to_dot",
-          "to_float"
+          "to_float",
+          "if_cm_to_mm"
         ]
       },
       "orditura": {
@@ -804,7 +803,7 @@
         "\\b([1-3])\\s*lastre\\b|\\b(doppia|tripla)\\s+lastra\\b"
       ],
       "spessore_lastra_mm": [
-        "\\b(10|12[.,]5|15|18)\\s*mm\\b"
+        "\\b(\\d{1,3}(?:[.,]\\d+)?)\\s*(?:mm|cm)\\b"
       ],
       "spessore_orditura_mm": [
         "\\b(U|CW|UW)\\s?(50|75|100|125)\\b|\\bprofil[oi]\\s*(50|75|100|125)\\s*mm\\b"
@@ -831,16 +830,16 @@
         ]
       },
       "spessore_lastra_mm": {
-        "type": "enum",
-        "values": [
-          10,
-          12.5,
-          15,
-          "ignoto"
+        "type": "float",
+        "range": [
+          5,
+          200
         ],
+        "unknown": "ignoto",
         "normalizers": [
           "comma_to_dot",
-          "to_float"
+          "to_float",
+          "if_cm_to_mm"
         ]
       },
       "orditura": {
@@ -899,17 +898,16 @@
     ],
     "slots": {
       "spessore_lastra_mm": {
-        "type": "enum",
-        "values": [
-          8,
-          10,
-          12.5,
-          15,
-          "ignoto"
+        "type": "float",
+        "range": [
+          5,
+          200
         ],
+        "unknown": "ignoto",
         "normalizers": [
           "comma_to_dot",
-          "to_float"
+          "to_float",
+          "if_cm_to_mm"
         ]
       },
       "lastre_per_lato": {
@@ -954,7 +952,7 @@
     },
     "patterns": {
       "spessore_lastra_mm": [
-        "\\b(8|10|12[.,]5|15)\\s*mm\\b"
+        "\\b(\\d{1,3}(?:[.,]\\d+)?)\\s*(?:mm|cm)\\b"
       ],
       "spessore_orditura_mm": [
         "\\b(U|CW|UW)\\s?(50|75|100|125)\\b|\\bprofil[oi]\\s*(50|75|100|125)\\s*mm\\b"
@@ -1011,17 +1009,16 @@
         ]
       },
       "spessore_lastra_mm": {
-        "type": "enum",
-        "values": [
-          10,
-          12.5,
-          15,
-          18,
-          "ignoto"
+        "type": "float",
+        "range": [
+          5,
+          200
         ],
+        "unknown": "ignoto",
         "normalizers": [
           "comma_to_dot",
-          "to_float"
+          "to_float",
+          "if_cm_to_mm"
         ]
       },
       "isolante": {
@@ -1091,17 +1088,16 @@
         ]
       },
       "spessore_lastra_mm": {
-        "type": "enum",
-        "values": [
-          10,
-          12.5,
-          15,
-          18,
-          "ignoto"
+        "type": "float",
+        "range": [
+          5,
+          200
         ],
+        "unknown": "ignoto",
         "normalizers": [
           "comma_to_dot",
-          "to_float"
+          "to_float",
+          "if_cm_to_mm"
         ]
       },
       "isolante": {
@@ -1133,7 +1129,7 @@
     },
     "patterns": {
       "spessore_lastra_mm": [
-        "\\b(10|12[.,]5|15|18)\\s*mm\\b"
+        "\\b(\\d{1,3}(?:[.,]\\d+)?)\\s*(?:mm|cm)\\b"
       ],
       "lastre_per_lato": [
         "\\b([1-4])\\s*lastre\\b|\\b(doppia|tripla|quadrupla)\\s+lastra\\b"
@@ -1151,17 +1147,16 @@
     ],
     "slots": {
       "spessore_lastra_mm": {
-        "type": "enum",
-        "values": [
-          8,
-          10,
-          12.5,
-          15,
-          "ignoto"
+        "type": "float",
+        "range": [
+          5,
+          200
         ],
+        "unknown": "ignoto",
         "normalizers": [
           "comma_to_dot",
-          "to_float"
+          "to_float",
+          "if_cm_to_mm"
         ]
       },
       "orditura": {
@@ -1206,7 +1201,7 @@
     },
     "patterns": {
       "spessore_lastra_mm": [
-        "\\b(8|10|12[.,]5|15)\\s*mm\\b"
+        "\\b(\\d{1,3}(?:[.,]\\d+)?)\\s*(?:mm|cm)\\b"
       ],
       "spessore_orditura_mm": [
         "\\b(U|CW|UW)\\s?(50|75|100|125)\\b|\\bprofil[oi]\\s*(50|75|100|125)\\s*mm\\b"
@@ -1415,17 +1410,16 @@
         "unknown": "ignoto"
       },
       "spessore_lastra_mm": {
-        "type": "enum",
-        "values": [
-          8,
-          10,
-          12.5,
-          15,
-          "ignoto"
+        "type": "float",
+        "range": [
+          5,
+          200
         ],
+        "unknown": "ignoto",
         "normalizers": [
           "comma_to_dot",
-          "to_float"
+          "to_float",
+          "if_cm_to_mm"
         ]
       },
       "note_tecniche": {
@@ -3599,12 +3593,16 @@
         ]
       },
       "spessore_lastra_mm": {
-        "type": "enum",
-        "values": [
-          10,
-          12.5,
-          15,
-          "ignoto"
+        "type": "float",
+        "range": [
+          5,
+          200
+        ],
+        "unknown": "ignoto",
+        "normalizers": [
+          "comma_to_dot",
+          "to_float",
+          "if_cm_to_mm"
         ]
       },
       "spessore_orditura_mm": {
@@ -3629,7 +3627,7 @@
     },
     "patterns": {
       "spessore_lastra_mm": [
-        "\\b(10|12[.,]5|15)\\s*mm\\b"
+        "\\b(\\d{1,3}(?:[.,]\\d+)?)\\s*(?:mm|cm)\\b"
       ],
       "spessore_orditura_mm": [
         "\\b(U|CD|UD|CW|UW)\\s?(50|75|100|125)\\b"
@@ -3755,12 +3753,16 @@
         "unknown": "ignoto"
       },
       "spessore_lastra_mm": {
-        "type": "enum",
-        "values": [
-          10,
-          12.5,
-          15,
-          "ignoto"
+        "type": "float",
+        "range": [
+          5,
+          200
+        ],
+        "unknown": "ignoto",
+        "normalizers": [
+          "comma_to_dot",
+          "to_float",
+          "if_cm_to_mm"
         ]
       },
       "note_tecniche": {

--- a/docs/extraction_checklist.md
+++ b/docs/extraction_checklist.md
@@ -1,5 +1,5 @@
 # Checklist estrazione proprietà prioritari
-Generata automaticamente il 2025-09-23 17:17:51Z a partire da `data/properties_registry_extended.json`.
+Generata automaticamente il 2025-09-23 21:16:20Z a partire da `data/properties_registry_extended.json`.
 Per ogni categoria sono elencati gli slot prioritari strutturati (numerici, enum, stringhe) con le regex di supporto e i normalizzatori suggeriti.
 
 ## Apparecchi sanitari e accessori|Accessori per l'allestimento di servizi igienici
@@ -159,7 +159,7 @@ Per ogni categoria sono elencati gli slot prioritari strutturati (numerici, enum
 ## Controsoffitti|Controsoffitti in cartongesso
 | Proprietà | Tipo | Regex | Normalizzatori |
 | --- | --- | --- | --- |
-| `spessore_lastra_mm` | enum | `\b(10|12[.,]5|15)\s*cm\b`<br>`\b(10|12[.,]5|15)\s*mm\b` | `lower`, `split_structured_list` |
+| `spessore_lastra_mm` | float | `\b(\d{1,3}(?:[.,]\d+)?)\s*(?:mm|cm)\b` | `comma_to_dot`, `to_float`, `if_cm_to_mm` |
 
 ## Controsoffitti|Controsoffitti in fibre minerali e acustici
 | Proprietà | Tipo | Regex | Normalizzatori |
@@ -307,7 +307,7 @@ Per ogni categoria sono elencati gli slot prioritari strutturati (numerici, enum
 ## Opere da cartongessista|Contropareti in lastre di fibrocemento
 | Proprietà | Tipo | Regex | Normalizzatori |
 | --- | --- | --- | --- |
-| `spessore_lastra_mm` | enum | `\b(8|10|12[.,]5|15)\s*cm\b`<br>`\b(8|10|12[.,]5|15)\s*mm\b` | `comma_to_dot`, `to_float` |
+| `spessore_lastra_mm` | float | `\b(\d{1,3}(?:[.,]\d+)?)\s*(?:mm|cm)\b` | `comma_to_dot`, `to_float`, `if_cm_to_mm` |
 | `spessore_orditura_mm` | enum | `\b(U|CW|UW)\s?(50|75|100|125)\b|\bprofil[oi]\s*(50|75|100|125)\s*cm\b`<br>`\b(U|CW|UW)\s?(50|75|100|125)\b|\bprofil[oi]\s*(50|75|100|125)\s*mm\b` | `lower` |
 
 ## Opere da cartongessista|Pareti in cartongesso resistente al fuoco
@@ -322,12 +322,12 @@ Per ogni categoria sono elencati gli slot prioritari strutturati (numerici, enum
 | --- | --- | --- | --- |
 | `spessore_orditura_mm` | enum | `\b(U|CW|UW)\s?(50|75|100|125)\b|\bprofil[oi]\s*(50|75|100|125)\s*cm\b`<br>`\b(U|CW|UW)\s?(50|75|100|125)\b|\bprofil[oi]\s*(50|75|100|125)\s*mm\b` | `lower` |
 | `lastre_per_lato` | int | `\b([1-4])\s*lastre\b|\b(doppia|tripla|quadrupla)\s+lastra\b` | `to_strati_count` |
-| `spessore_lastra_mm` | enum | `\b(10|12[.,]5|15|18)\s*cm\b`<br>`\b(10|12[.,]5|15|18)\s*mm\b` | `comma_to_dot`, `to_float` |
+| `spessore_lastra_mm` | float | `\b(\d{1,3}(?:[.,]\d+)?)\s*(?:mm|cm)\b` | `comma_to_dot`, `to_float`, `if_cm_to_mm` |
 
 ## Opere da cartongessista|Pareti in lastre di fibrocemento
 | Proprietà | Tipo | Regex | Normalizzatori |
 | --- | --- | --- | --- |
-| `spessore_lastra_mm` | enum | `\b(8|10|12[.,]5|15)\s*cm\b`<br>`\b(8|10|12[.,]5|15)\s*mm\b` | `comma_to_dot`, `to_float` |
+| `spessore_lastra_mm` | float | `\b(\d{1,3}(?:[.,]\d+)?)\s*(?:mm|cm)\b` | `comma_to_dot`, `to_float`, `if_cm_to_mm` |
 | `spessore_orditura_mm` | enum | `\b(U|CW|UW)\s?(50|75|100|125)\b|\bprofil[oi]\s*(50|75|100|125)\s*cm\b`<br>`\b(U|CW|UW)\s?(50|75|100|125)\b|\bprofil[oi]\s*(50|75|100|125)\s*mm\b` | `lower` |
 
 ## Opere da cartongessista|Setto autoportante cartongesso resistente al fuoco

--- a/pack/current/pack.json
+++ b/pack/current/pack.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generated_at": "2025-09-23T17:17:51Z",
+  "generated_at": "2025-09-23T21:16:20Z",
   "patterns": [
     {
       "property_id": "CER_codice",
@@ -3234,18 +3234,12 @@
     {
       "property_id": "spessore_lastra_mm",
       "regex": [
-        "\\b(10|12[.,]5|15)\\s*cm\\b",
-        "\\b(10|12[.,]5|15)\\s*mm\\b",
-        "\\b(10|12[.,]5|15|18)\\s*cm\\b",
-        "\\b(10|12[.,]5|15|18)\\s*mm\\b",
-        "\\b(8|10|12[.,]5|15)\\s*cm\\b",
-        "\\b(8|10|12[.,]5|15)\\s*mm\\b"
+        "\\b(\\d{1,3}(?:[.,]\\d+)?)\\s*(?:mm|cm)\\b"
       ],
       "normalizers": [
-        "lower",
-        "split_structured_list",
         "comma_to_dot",
-        "to_float"
+        "to_float",
+        "if_cm_to_mm"
       ],
       "language": "it",
       "confidence": 0.85,
@@ -3253,7 +3247,7 @@
         "category:Controsoffitti",
         "category:Opere da cartongessista",
         "priority",
-        "slot_type:enum",
+        "slot_type:float",
         "subcategory:Contropareti in cartongesso resistente al fuoco",
         "subcategory:Contropareti in lastre di fibrocemento",
         "subcategory:Controsoffitti in cartongesso",

--- a/src/robimb/extraction/resources/extractors.json
+++ b/src/robimb/extraction/resources/extractors.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generated_at": "2025-09-23T17:17:51Z",
+  "generated_at": "2025-09-23T21:16:20Z",
   "patterns": [
     {
       "property_id": "CER_codice",
@@ -3234,18 +3234,12 @@
     {
       "property_id": "spessore_lastra_mm",
       "regex": [
-        "\\b(10|12[.,]5|15)\\s*cm\\b",
-        "\\b(10|12[.,]5|15)\\s*mm\\b",
-        "\\b(10|12[.,]5|15|18)\\s*cm\\b",
-        "\\b(10|12[.,]5|15|18)\\s*mm\\b",
-        "\\b(8|10|12[.,]5|15)\\s*cm\\b",
-        "\\b(8|10|12[.,]5|15)\\s*mm\\b"
+        "\\b(\\d{1,3}(?:[.,]\\d+)?)\\s*(?:mm|cm)\\b"
       ],
       "normalizers": [
-        "lower",
-        "split_structured_list",
         "comma_to_dot",
-        "to_float"
+        "to_float",
+        "if_cm_to_mm"
       ],
       "language": "it",
       "confidence": 0.85,
@@ -3253,7 +3247,7 @@
         "category:Controsoffitti",
         "category:Opere da cartongessista",
         "priority",
-        "slot_type:enum",
+        "slot_type:float",
         "subcategory:Contropareti in cartongesso resistente al fuoco",
         "subcategory:Contropareti in lastre di fibrocemento",
         "subcategory:Controsoffitti in cartongesso",

--- a/src/robimb/extraction/resources/extractors_patterns.json
+++ b/src/robimb/extraction/resources/extractors_patterns.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generated_at": "2025-09-23T17:17:51Z",
+  "generated_at": "2025-09-23T21:16:20Z",
   "patterns": [
     {
       "property_id": "CER_codice",
@@ -3234,18 +3234,12 @@
     {
       "property_id": "spessore_lastra_mm",
       "regex": [
-        "\\b(10|12[.,]5|15)\\s*cm\\b",
-        "\\b(10|12[.,]5|15)\\s*mm\\b",
-        "\\b(10|12[.,]5|15|18)\\s*cm\\b",
-        "\\b(10|12[.,]5|15|18)\\s*mm\\b",
-        "\\b(8|10|12[.,]5|15)\\s*cm\\b",
-        "\\b(8|10|12[.,]5|15)\\s*mm\\b"
+        "\\b(\\d{1,3}(?:[.,]\\d+)?)\\s*(?:mm|cm)\\b"
       ],
       "normalizers": [
-        "lower",
-        "split_structured_list",
         "comma_to_dot",
-        "to_float"
+        "to_float",
+        "if_cm_to_mm"
       ],
       "language": "it",
       "confidence": 0.85,
@@ -3253,7 +3247,7 @@
         "category:Controsoffitti",
         "category:Opere da cartongessista",
         "priority",
-        "slot_type:enum",
+        "slot_type:float",
         "subcategory:Contropareti in cartongesso resistente al fuoco",
         "subcategory:Contropareti in lastre di fibrocemento",
         "subcategory:Controsoffitti in cartongesso",


### PR DESCRIPTION
## Summary
- widen the spessore_lastra_mm slots to floats with a cm/mm-friendly pattern and cm-to-mm normalisation
- regenerate the extractor pack and checklist so downstream resources pick up the broader rule

## Testing
- python scripts/build_extractors_pack.py
- PYTHONPATH=src python -m robimb.cli.convert --train-file tmp_sample.jsonl --val-split 0.5 --ontology data/ontology.json --label-maps tmp_output/label_maps.json --out-dir tmp_output --properties-registry data/properties_registry_extended.json --extractors-pack src/robimb/extraction/resources/extractors.json

------
https://chatgpt.com/codex/tasks/task_e_68d30c8345e4832290e8a3844e418cc0