### PR TITLE
Filter empty regex groups in captures

### DIFF
--- a/src/robimb/extraction/engine.py
+++ b/src/robimb/extraction/engine.py
@@ -85,14 +85,24 @@ def _apply_normalizers(
 
 
 def _coerce_capture(match: re.Match[str]) -> Any:
+    """Normalize match groups dropping empty values."""
+
     # No groups: return entire matched text
     if match.lastindex is None:
         return match.group(0)
-    # 1 group: return that group
-    if match.lastindex == 1:
-        return match.group(1)
-    # 2+ groups: return tuple of groups
-    return tuple(match.group(i) for i in range(1, match.lastindex + 1))
+
+    groups = [match.group(i) for i in range(1, match.lastindex + 1)]
+
+    def _is_empty(value: Any) -> bool:
+        return value is None or (isinstance(value, str) and value == "")
+
+    cleaned = [value for value in groups if not _is_empty(value)]
+
+    if not cleaned:
+        return None
+    if len(cleaned) == 1:
+        return cleaned[0]
+    return cleaned
 
 
 def extract_properties(

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -43,3 +43,21 @@ def test_pack_v1_normalizers_examples():
     assert props["geo.foratura_laterizio"] == "semipieno"
     assert abs(props["qty.spessore"] - 25.0) < 1e-6
     assert props["aco.rw"] == 54
+
+
+def test_empty_groups_are_filtered():
+    extractors_pack = {
+        "version": "0.0.1",
+        "patterns": [
+            {
+                "property_id": "safety.classe",
+                "regex": [r"classe_EN795\s+(?:([A-Z])|([a-z]))"],
+                "normalizers": [],
+            }
+        ],
+    }
+    text = "Dispositivo di ancoraggio classe_EN795 e"
+
+    props = extract_properties(text, extractors_pack)
+
+    assert props["safety.classe"] == "e"


### PR DESCRIPTION
## Summary
- drop empty and None capture groups when coercing regex matches
- default to a single string when only one meaningful capture remains
- add regression test covering classe_EN795 extraction output

## Testing
- pytest tests/test_extractors.py

------
https://chatgpt.com/codex/tasks/task_e_68d38a3ce09c832293eb8851dd982772