### PR TITLE
Wire default property resources into convert CLI

### DIFF
--- a/src/robimb/cli/convert.py
+++ b/src/robimb/cli/convert.py
@@ -28,7 +28,30 @@ __all__ = [
 ]
 
 
-DEFAULT_EXTRACTORS_PACK = extraction_resources.default_path()
+_DATA_PROPERTIES_DIR = Path(__file__).resolve().parents[3] / "data" / "properties"
+
+
+def _resolve_default_registry_path() -> Optional[Path]:
+    for name in ("properties_registry_extended.json", "properties_registry.json"):
+        candidate = _DATA_PROPERTIES_DIR / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _resolve_default_extractors_path() -> Optional[Path]:
+    for name in ("extractors_extended.json", "extractors.json"):
+        candidate = _DATA_PROPERTIES_DIR / name
+        if candidate.exists():
+            return candidate
+    bundled = extraction_resources.default_path()
+    if bundled.exists():
+        return bundled
+    return None
+
+
+DEFAULT_PROPERTIES_REGISTRY = _resolve_default_registry_path()
+DEFAULT_EXTRACTORS_PACK = _resolve_default_extractors_path()
 
 
 @dataclass(frozen=True)
@@ -47,8 +70,8 @@ class ConversionConfig:
     mlm_output: Optional[Path] = None
     extra_mlm: Sequence[Path] = ()
     reports_dir: Optional[Path] = None
-    properties_registry: Optional[Path] = None
-    extractors_pack: Optional[Path] = None
+    properties_registry: Optional[Path] = DEFAULT_PROPERTIES_REGISTRY
+    extractors_pack: Optional[Path] = DEFAULT_EXTRACTORS_PACK
     text_field: str = "text"
 
     def iter_mlm_sources(self) -> Iterable[Path]:
@@ -199,12 +222,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--properties-registry",
-        default=None,
+        default=str(DEFAULT_PROPERTIES_REGISTRY) if DEFAULT_PROPERTIES_REGISTRY else None,
         help="Optional registry JSON or knowledge pack containing property schemas to attach to rows",
     )
     parser.add_argument(
         "--extractors-pack",
-        default=str(DEFAULT_EXTRACTORS_PACK) if DEFAULT_EXTRACTORS_PACK.exists() else None,
+        default=str(DEFAULT_EXTRACTORS_PACK) if DEFAULT_EXTRACTORS_PACK else None,
         help="Knowledge pack or extractors JSON used to auto-extract properties during conversion",
     )
     parser.add_argument(

--- a/src/robimb/cli/main.py
+++ b/src/robimb/cli/main.py
@@ -8,14 +8,11 @@ from typing import List, Optional, Sequence
 import typer
 
 from .._version import __version__
-from ..extraction import resources as extraction_resources
+from .convert import DEFAULT_EXTRACTORS_PACK, DEFAULT_PROPERTIES_REGISTRY
 
 __all__ = ["app", "run"]
 
 app = typer.Typer(help="Production-ready BIM NLP pipeline utilities", add_completion=False)
-
-DEFAULT_EXTRACTORS_PATH = extraction_resources.default_path()
-
 
 @app.callback(invoke_without_command=True)
 def version_callback(
@@ -54,14 +51,14 @@ def convert_command(
         help="Directory where dataset plots and summary files will be saved",
     ),
     properties_registry: Optional[Path] = typer.Option(
-        None,
+        DEFAULT_PROPERTIES_REGISTRY,
         "--properties-registry",
         exists=True,
         dir_okay=False,
         help="Optional registry JSON or knowledge pack containing property schemas",
     ),
     extractors_pack: Optional[Path] = typer.Option(
-        DEFAULT_EXTRACTORS_PATH if DEFAULT_EXTRACTORS_PATH.exists() else None,
+        DEFAULT_EXTRACTORS_PACK,
         "--extractors-pack",
         exists=True,
         dir_okay=False,


### PR DESCRIPTION
## Summary
- automatically resolve default property registry and extractor pack resources for the `convert` command
- derive extractor patterns from registry payloads so conversion can enrich properties without an explicit pack
- extend data conversion tests to cover registry-driven extraction fallback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d439d9be8883229bf35478f0fa0dcb