### PR TITLE
Support knowledge pack v4 registry layout

### DIFF
--- a/src/robimb/core/schemas/categories.schema.json
+++ b/src/robimb/core/schemas/categories.schema.json
@@ -1,54 +1,97 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "super",
-    "cat"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
-    },
-    "super": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "id",
-          "label"
-        ],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "cat": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "id",
-          "label",
-          "super_id"
-        ],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          },
-          "super_id": {
-            "type": "string"
-          }
-        }
-      }
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
     }
+  },
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "label": {
+        "type": "string"
+      },
+      "description": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "categories": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "slots": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "priority": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "unit": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "expected_atoms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      }
+    },
+    "required": [
+      "categories"
+    ],
+    "additionalProperties": true
   }
 }

--- a/src/robimb/core/schemas/catmap.schema.json
+++ b/src/robimb/core/schemas/catmap.schema.json
@@ -1,93 +1,61 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "mappings"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
     },
     "mappings": {
       "type": "array",
       "items": {
         "type": "object",
         "required": [
-          "cat_id",
+          "super_label",
           "cat_label",
-          "super_id",
-          "super_label"
+          "key"
         ],
         "properties": {
-          "cat_id": {
+          "super_label": {
             "type": "string"
           },
           "cat_label": {
             "type": "string"
           },
+          "key": {
+            "type": "string"
+          },
           "super_id": {
-            "type": "string"
-          },
-          "super_label": {
-            "type": "string"
-          },
-          "props_required": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "props_recommended": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "groups_required": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "groups_recommended": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "ifc_classes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "negative_keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "keynote_mapping": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "type_profile": {
             "type": [
               "string",
               "null"
             ]
+          },
+          "cat_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
-        }
+        },
+        "additionalProperties": true
       }
     }
-  }
+  },
+  "required": [
+    "mappings"
+  ],
+  "additionalProperties": true
 }

--- a/src/robimb/core/schemas/contexts.schema.json
+++ b/src/robimb/core/schemas/contexts.schema.json
@@ -1,16 +1,42 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "dimensions"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
     },
     "dimensions": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "values": {
+            "type": [
+              "array",
+              "object"
+            ],
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      }
     }
-  }
+  },
+  "required": [
+    "dimensions"
+  ],
+  "additionalProperties": true
 }

--- a/src/robimb/core/schemas/extractors.schema.json
+++ b/src/robimb/core/schemas/extractors.schema.json
@@ -1,14 +1,75 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "patterns",
-    "normalizers"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "alias_hints": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "normalizers": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "atoms_embedded": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "atoms": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "pattern_id",
+              "regex"
+            ],
+            "properties": {
+              "pattern_id": {
+                "type": "string"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "regex": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "normalizers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "validation": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
     },
     "patterns": {
       "type": "array",
@@ -25,7 +86,10 @@
           "regex": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": [
+                "string",
+                "object"
+              ]
             }
           },
           "normalizers": {
@@ -33,13 +97,30 @@
             "items": {
               "type": "string"
             }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "confidence": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "defaults": {
+            "type": "object",
+            "additionalProperties": true
           }
-        }
+        },
+        "additionalProperties": true
       }
-    },
-    "normalizers": {
-      "type": "object",
-      "additionalProperties": {}
     }
-  }
+  },
+  "required": [
+    "patterns"
+  ],
+  "additionalProperties": true
 }

--- a/src/robimb/core/schemas/formulas.schema.json
+++ b/src/robimb/core/schemas/formulas.schema.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "computed"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
     },
     "computed": {
       "type": "array",
@@ -23,9 +20,20 @@
           },
           "expr": {
             "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
-        }
+        },
+        "additionalProperties": true
       }
     }
-  }
+  },
+  "required": [
+    "computed"
+  ],
+  "additionalProperties": true
 }

--- a/src/robimb/core/schemas/manifest.schema.json
+++ b/src/robimb/core/schemas/manifest.schema.json
@@ -1,35 +1,34 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "generated_at",
-    "files"
-  ],
   "properties": {
-    "generated_at": {
-      "type": "string"
+    "schema": {
+      "type": [
+        "string",
+        "object",
+        "null"
+      ]
     },
-    "files": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "path",
-          "size",
-          "sha256"
-        ],
-        "properties": {
-          "path": {
-            "type": "string"
-          },
-          "size": {
-            "type": "integer"
-          },
-          "sha256": {
-            "type": "string"
-          }
-        }
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "sources": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
       }
+    },
+    "extractors_metadata": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
     }
-  }
+  },
+  "required": [
+    "metadata"
+  ],
+  "additionalProperties": true
 }

--- a/src/robimb/core/schemas/profiles.schema.json
+++ b/src/robimb/core/schemas/profiles.schema.json
@@ -1,16 +1,32 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "profiles"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
     },
     "profiles": {
-      "type": "array"
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      ]
     }
-  }
+  },
+  "required": [
+    "profiles"
+  ],
+  "additionalProperties": true
 }

--- a/src/robimb/core/schemas/registry.schema.json
+++ b/src/robimb/core/schemas/registry.schema.json
@@ -1,110 +1,111 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "groups",
-    "properties",
-    "enums"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
-    },
-    "groups": {
+    "metadata": {
       "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "required": [
-          "label",
-          "properties"
-        ],
-        "properties": {
-          "label": {
-            "type": "string"
-          },
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    "properties": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "required": [
-          "id",
-          "group",
-          "label",
-          "type"
-        ],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "group": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "string",
-              "number",
-              "integer",
-              "boolean",
-              "enum"
-            ]
-          },
-          "uom": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "enum": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "standards": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    "enums": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "required": [
-          "values"
-        ],
-        "properties": {
-          "values": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      }
+      "additionalProperties": true
     }
+  },
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "label": {
+        "type": "string"
+      },
+      "description": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "super_label": {
+        "type": "string"
+      },
+      "cat_label": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "defaults": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "slots": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "priority": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "unit": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "expected_atoms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "validators": {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "object"
+                ]
+              }
+            },
+            "defaults": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "patterns": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "object"
+            ]
+          }
+        }
+      }
+    },
+    "additionalProperties": true
   }
 }

--- a/src/robimb/core/schemas/templates.schema.json
+++ b/src/robimb/core/schemas/templates.schema.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "templates"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
     },
     "templates": {
       "type": "array",
@@ -26,10 +23,17 @@
           },
           "fallbacks": {
             "type": "object",
-            "additionalProperties": {}
+            "additionalProperties": {
+              "type": "string"
+            }
           }
-        }
+        },
+        "additionalProperties": true
       }
     }
-  }
+  },
+  "required": [
+    "templates"
+  ],
+  "additionalProperties": true
 }

--- a/src/robimb/core/schemas/validators.schema.json
+++ b/src/robimb/core/schemas/validators.schema.json
@@ -1,35 +1,90 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "rules"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
     },
     "rules": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "if",
-          "assert",
-          "message"
-        ],
         "properties": {
+          "id": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "when": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "requires": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "range": {
+            "type": "object",
+            "properties": {
+              "prop": {
+                "type": "string"
+              },
+              "min": {
+                "type": "number"
+              },
+              "max": {
+                "type": "number"
+              }
+            },
+            "additionalProperties": true
+          },
+          "enum": {
+            "type": "object",
+            "properties": {
+              "prop": {
+                "type": "string"
+              },
+              "in": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": true
+          },
+          "regex": {
+            "type": "object",
+            "properties": {
+              "prop": {
+                "type": "string"
+              },
+              "pattern": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
           "if": {
             "type": "string"
           },
           "assert": {
             "type": "string"
-          },
-          "message": {
-            "type": "string"
           }
-        }
+        },
+        "additionalProperties": true
       }
     }
-  }
+  },
+  "required": [
+    "rules"
+  ],
+  "additionalProperties": true
 }

--- a/src/robimb/core/schemas/views.schema.json
+++ b/src/robimb/core/schemas/views.schema.json
@@ -1,16 +1,32 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "version",
-    "views"
-  ],
   "properties": {
-    "version": {
-      "type": "string"
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
     },
     "views": {
-      "type": "array"
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      ]
     }
-  }
+  },
+  "required": [
+    "views"
+  ],
+  "additionalProperties": true
 }


### PR DESCRIPTION
## Summary
- flatten the hierarchical knowledge pack v4 registry into slugged property identifiers and preserve metadata/patterns for extraction
- extend the registry normalizer to detect v4 payloads so dataset preparation keeps property schemas populated
- update data preparation tests to use the new registry structure and sanitized property IDs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d469f8f29483229995d92ca666ddc7