### PR TITLE
Add massetti sottofondi property extraction

### DIFF
--- a/data/properties/extractors.json
+++ b/data/properties/extractors.json
@@ -1190,6 +1190,800 @@
   },
   "patterns": [
     {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.spessore_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:medio\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Cappe di completamento"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.71
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.spessore_min_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:da|min(?:imo)?|variabile\\s+da)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:min(?:imo)?|min\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Cappe di completamento"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.spessore_max_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:fino\\s?a|max(?:imo)?|massimo|max\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:da\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*)(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Cappe di completamento"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.massa_volumica_kg_m3",
+      "regex": [
+        "(?i)\\bmassa\\s+volumica(?:\\s+nominale)?(?:\\s+in\\s+opera)?\\s*(?:pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+        "(?i)\\bdensit[àa]\\s*(?:in\\s+opera\\s*)?(?:circa\\s*|pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³",
+      "applies_to": {
+        "cats": [
+          "Cappe di completamento"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "kg/m³"
+      },
+      "confidence": 0.69
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.resistenza_compressione_N_mm2",
+      "regex": [
+        "(?i)\\bresistenza\\s+(?:media\\s+)?(?:a\\s+)?compressione(?:\\s+certificata)?\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|n/mm\\u00b2|mpa)\\b",
+        "(?i)\\bclasse\\s+di\\s+compressione\\s*(?:c|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|mpa)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "N/mm²",
+      "applies_to": {
+        "cats": [
+          "Cappe di completamento"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "N/mm²"
+      },
+      "confidence": 0.69
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.conducibilita_termica_W_mK",
+      "regex": [
+        "(?i)\\b(?:conducibilit[àa]\\s+termica|lambda|λ)\\s*(?:certificata\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1}(?:[.,]\\d{1,3})?)\\s*(?:w\\s*/?\\s*m?k)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "termica"
+      ],
+      "unit": "W/mK",
+      "applies_to": {
+        "cats": [
+          "Cappe di completamento"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "W/mK"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.spessore_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:medio\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Massetti alleggeriti"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.71
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.spessore_min_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:da|min(?:imo)?|variabile\\s+da)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:min(?:imo)?|min\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Massetti alleggeriti"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.spessore_max_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:fino\\s?a|max(?:imo)?|massimo|max\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:da\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*)(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Massetti alleggeriti"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.massa_volumica_kg_m3",
+      "regex": [
+        "(?i)\\bmassa\\s+volumica(?:\\s+nominale)?(?:\\s+in\\s+opera)?\\s*(?:pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+        "(?i)\\bdensit[àa]\\s*(?:in\\s+opera\\s*)?(?:circa\\s*|pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³",
+      "applies_to": {
+        "cats": [
+          "Massetti alleggeriti"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "kg/m³"
+      },
+      "confidence": 0.69
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.resistenza_compressione_N_mm2",
+      "regex": [
+        "(?i)\\bresistenza\\s+(?:media\\s+)?(?:a\\s+)?compressione(?:\\s+certificata)?\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|n/mm\\u00b2|mpa)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "N/mm²",
+      "applies_to": {
+        "cats": [
+          "Massetti alleggeriti"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "N/mm²"
+      },
+      "confidence": 0.69
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.conducibilita_termica_W_mK",
+      "regex": [
+        "(?i)\\b(?:conducibilit[àa]\\s+termica|lambda|λ)\\s*(?:certificata\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1}(?:[.,]\\d{1,3})?)\\s*(?:w\\s*/?\\s*m?k)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "termica"
+      ],
+      "unit": "W/mK",
+      "applies_to": {
+        "cats": [
+          "Massetti alleggeriti"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "W/mK"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.spessore_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:variabile\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Massetti pendenzati"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.71
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.spessore_min_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:da|min(?:imo)?|variabile\\s+da)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:min(?:imo)?|min\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Massetti pendenzati"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.spessore_max_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:variabile\\s*fino\\s*a|fino\\s*a|max(?:imo)?|massimo|max\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:da\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*)(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Massetti pendenzati"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.dosaggio_cemento_kg_m3",
+      "regex": [
+        "(?i)\\b(?:dosat[oa]|dosaggio)\\s*(?:a\\s*)?(?:minimo\\s*)?(?P<val>\\d{2,4}(?:[.,]\\d{1,2})?)\\s*(?:kg)\\b[^\\n]{0,60}?\\b(?:per\\s*(?:m(?:c|3)|metro\\s+cubo))"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³",
+      "applies_to": {
+        "cats": [
+          "Massetti pendenzati"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "kg/m³"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.resistenza_Rck_N_mm2",
+      "regex": [
+        "(?i)\\brck\\s*(?:=|:|pari\\s*a)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|n/mm\\u00b2|mpa)\\b",
+        "(?i)\\bresistenza\\s+maggiore\\s+di\\s*rck\\s*=\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|mpa)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "N/mm²",
+      "applies_to": {
+        "cats": [
+          "Massetti pendenzati"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "N/mm²"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.spessore_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:medio\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Sottofondi pavimentazioni"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.71
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.spessore_min_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:da|min(?:imo)?|variabile\\s+da)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:min(?:imo)?|min\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Sottofondi pavimentazioni"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.spessore_max_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:fino\\s?a|max(?:imo)?|massimo|max\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:da\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*)(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Sottofondi pavimentazioni"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.massa_volumica_kg_m3",
+      "regex": [
+        "(?i)\\bmassa\\s+volumica(?:\\s+nominale)?(?:\\s+in\\s+opera)?\\s*(?:pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+        "(?i)\\bdensit[àa]\\s*(?:in\\s+opera\\s*)?(?:circa\\s*|pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³",
+      "applies_to": {
+        "cats": [
+          "Sottofondi pavimentazioni"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "kg/m³"
+      },
+      "confidence": 0.69
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.rete_diametro_mm",
+      "regex": [
+        "(?i)\\bdiametro\\s*(?:di|Ø|ø)?\\s*(?:ø)?\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b",
+        "(?i)\\bØ\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b",
+        "(?i)\\b(?:tondini|barre)\\s+di\\s+diametro\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Sottofondi pavimentazioni"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.rete_maglia_mm",
+      "regex": [
+        "(?i)\\bmaglia\\s*(?P<a>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*[x×]\\s*(?P<b>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm)\\b",
+        "(?i)\\bmaglia\\s*(?P<a>\\d{1,3})\\s*[x×]\\s*(?P<b>\\d{1,3})\\s*cm\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "normalize_dimensions_to_mm",
+        "strip"
+      ],
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm×mm",
+      "applies_to": {
+        "cats": [
+          "Sottofondi pavimentazioni"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm×mm"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.teli_di_separazione.spessore_mm",
+      "regex": [
+        "(?i)\\bsp(?:essore|\\.)\\s*(?:nominale\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Teli di separazione"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.69
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.teli_di_separazione.sovrapposizione_min_cm",
+      "regex": [
+        "(?i)\\bsovrappost[oi]\\s+(?:sulle\\s+giunture\\s+)?(?:di|per)\\s+(?:almeno\\s+)?(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*cm\\b",
+        "(?i)\\bgiunti\\s+sovrapposti\\s+di\\s+(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*cm\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "cm",
+      "applies_to": {
+        "cats": [
+          "Teli di separazione"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "cm"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.teli_di_separazione.peso_areico_kg_m2",
+      "regex": [
+        "(?i)\\bpeso\\s*(?:areico\\s*)?(?P<val>\\d{1,3}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:q|2|²))\\b",
+        "(?i)\\bpeso\\s*(?:kg\\s*/?\\s*m(?:q|2|²))\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,3})?)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m²",
+      "applies_to": {
+        "cats": [
+          "Teli di separazione"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "kg/m²"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.vespai_aerati.soletta_spessore_min_mm",
+      "regex": [
+        "(?i)\\bsoletta[^\\n]{0,60}?sp(?:essore|\\.)\\s*(?:min(?:imo)?|almeno|min\\.)\\s*(?:di\\s*)?(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Vespai aerati"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.vespai_aerati.casseri_altezza_mm",
+      "regex": [
+        "(?i)\\b(?:casseri|elementi\\s+modulari|vespaio)\\b[^\\n]{0,60}?altezza\\s*(?:media\\s*)?(?:di|pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Vespai aerati"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.vespai_aerati.rete_diametro_mm",
+      "regex": [
+        "(?i)\\brete[^\\n]{0,40}?diametro\\s*(?:di|Ø|ø)?\\s*(?:ø)?\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b",
+        "(?i)\\bØ\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "cats": [
+          "Vespai aerati"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "massetti_sottofondi_drenaggi_vespai.vespai_aerati.rete_maglia_mm",
+      "regex": [
+        "(?i)\\brete[^\\n]{0,40}?maglia\\s*(?P<a>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*[x×]\\s*(?P<b>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "normalize_dimensions_to_mm",
+        "strip"
+      ],
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm×mm",
+      "applies_to": {
+        "cats": [
+          "Vespai aerati"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm×mm"
+      },
+      "confidence": 0.68
+    },
+    {
       "property_id": "cantierizzazioni.__global__.produttore",
       "regex": [
         "(?i)\\\\b(?:produttore|brand|marca|manufacturer)\\\\b\\\\s*[:=\\\\-]?\\\\s*(?P<val>(?!(?:(?:RAL(?:\\\\s*\\\\d{2,4})?|GK[BFI]|DOP|POE|EER|CE|UNI(?:\\\\s*EN)?(?:\\\\s*ISO)?(?:\\\\s*\\\\d{2,5}(?:[-/]?\\\\d{1,2})?)?|EN(?:\\\\s*ISO)?(?:\\\\s*\\\\d{2,5}(?:[-/]?\\\\d{1,2})?)?|EN\\\\s*AW(?:[-\\\\s]*\\\\d{2,5})?|NTC(?:\\\\s*\\\\d{4})?|ISO(?:\\\\s*\\\\d{3,5}(?:[-/]?\\\\d{1,2})?)?|DIN(?:\\\\s*\\\\d{3,5}(?:[-/]?\\\\d{1,2})?)?|CEI(?:\\\\s*\\\\d{3,5}(?:[-/]?\\\\d{1,2})?)?|Uw(?:\\\\s*[=≤]\\\\s*\\\\d(?:[.,]\\\\d+)?)?))\\\\b)[A-Z][A-Za-z0-9\\\\-\\\\s&]{2,60})\\\\b",
@@ -1399,6 +2193,172 @@
         "unit": "m³"
       },
       "confidence": 0.73
+    },
+    {
+      "property_id": "cantierizzazioni.noli.altezza_operativa_m",
+      "regex": [
+        "(?i)\\baltezza(?:[^0-9]{0,40})?(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\b",
+        "(?i)\\baltezza\\s+(?:totale\\s+)?variabile\\s+da\\s+\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:m|mt|cm)\\s*(?:a|fino\\s+a)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\b",
+        "(?i)\\b(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\s+(?:di\\s+)?altezza\\b"
+      ],
+      "normalizers": [
+        "join_range",
+        "comma_to_dot",
+        "to_unit:m",
+        "strip"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "m",
+      "applies_to": {
+        "supercats": [
+          "Cantierizzazioni"
+        ],
+        "cats": [
+          "Noli"
+        ]
+      },
+      "examples": [
+        "Piattaforma telescopica articolata autocarrata ... altezza 30,00 m, sbraccio 15,00 m, portata 400 kg"
+      ],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "m"
+      },
+      "confidence": 0.74
+    },
+    {
+      "property_id": "cantierizzazioni.noli.sbraccio_operativo_m",
+      "regex": [
+        "(?i)\\bsbraccio(?:[^0-9]{0,30})?(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\b",
+        "(?i)\\b(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\s+(?:di\\s+)?sbraccio\\b"
+      ],
+      "normalizers": [
+        "join_range",
+        "comma_to_dot",
+        "to_unit:m",
+        "strip"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "m",
+      "applies_to": {
+        "supercats": [
+          "Cantierizzazioni"
+        ],
+        "cats": [
+          "Noli"
+        ]
+      },
+      "examples": [
+        "Piattaforma telescopica articolata autocarrata ... sbraccio 15,00 m"
+      ],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "m"
+      },
+      "confidence": 0.72
+    },
+    {
+      "property_id": "cantierizzazioni.noli.portata_massima_kg",
+      "regex": [
+        "(?i)\\bportata(?:[^0-9]{0,30})?(?P<val>\\d{1,6}(?:[.,]\\d{1,3})?)\\s*(?:kg|chilogrammi|t|tonnellate)\\b",
+        "(?i)\\b(?P<val>\\d{1,6}(?:[.,]\\d{1,3})?)\\s*(?:kg|chilogrammi|t|tonnellate)\\s+di\\s+portata\\b"
+      ],
+      "normalizers": [
+        "join_range",
+        "comma_to_dot",
+        "to_unit:kg",
+        "strip"
+      ],
+      "tags": [
+        "prestazioni"
+      ],
+      "unit": "kg",
+      "applies_to": {
+        "supercats": [
+          "Cantierizzazioni"
+        ],
+        "cats": [
+          "Noli"
+        ]
+      },
+      "examples": [
+        "Elevatore a cremagliera ... portata 1100 kg"
+      ],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "kg"
+      },
+      "confidence": 0.75
+    },
+    {
+      "property_id": "cantierizzazioni.noli.dimensioni_piattaforma_mm",
+      "regex": [
+        "(?i)\\bpiattaforma\\s*(?:di\\s+carico\\s*)?(?:dimensioni|misure|formato)\\s*(?:[:=]?\\s*)?(?P<a>\\d{2,5})(?:\\s*(?P<unit1>mm|cm|m))?\\s*[x×X]\\s*(?P<b>\\d{2,5})(?:\\s*(?P<unit2>mm|cm|m))?\\b",
+        "(?i)\\bdimensioni\\s*(?:della\\s+)?piattaforma\\s*(?:[:=]?\\s*)?(?P<a>\\d{2,5})(?:\\s*(?P<unit1>mm|cm|m))?\\s*[x×X]\\s*(?P<b>\\d{2,5})(?:\\s*(?P<unit2>mm|cm|m))?\\b"
+      ],
+      "normalizers": [
+        "normalize_dimensions_to_mm",
+        "validate_aspect_ratio",
+        "strip",
+        "comma_to_dot"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm×mm",
+      "applies_to": {
+        "supercats": [
+          "Cantierizzazioni"
+        ],
+        "cats": [
+          "Noli"
+        ]
+      },
+      "examples": [
+        "Elevatore a cremagliera ... piattaforma dimensioni 150x180 cm"
+      ],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm×mm"
+      },
+      "confidence": 0.73
+    },
+    {
+      "property_id": "cantierizzazioni.installazione_cantiere.dimensioni_cartello_mm",
+      "regex": [
+        "(?i)\\bcartello[^0-9]{0,80}?(?P<a>\\d{2,5})(?:\\s*(?P<unit1>mm|cm|m))?\\s*[x×X]\\s*(?P<b>\\d{2,5})(?:\\s*(?P<unit2>mm|cm|m))?\\b",
+        "(?i)\\bdimensioni?[^0-9]{0,40}?cartello[^0-9]{0,40}?(?P<a>\\d{2,5})(?:\\s*(?P<unit1>mm|cm|m))?\\s*[x×X]\\s*(?P<b>\\d{2,5})(?:\\s*(?P<unit2>mm|cm|m))?\\b"
+      ],
+      "normalizers": [
+        "normalize_dimensions_to_mm",
+        "validate_aspect_ratio",
+        "strip",
+        "comma_to_dot"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm×mm",
+      "applies_to": {
+        "supercats": [
+          "Cantierizzazioni"
+        ],
+        "cats": [
+          "Installazione cantiere"
+        ]
+      },
+      "examples": [
+        "Realizzazione di cartello di cantiere ... Dimensione di circa 200 x 140 cm"
+      ],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm×mm"
+      },
+      "confidence": 0.72
     },
     {
       "property_id": "assistenze_murarie.__global__.produttore",
@@ -1612,6 +2572,69 @@
       "confidence": 0.73
     },
     {
+      "property_id": "assistenze_murarie.assistenze_murarie_alla_posa_di_impianti.sezione_min_cm2",
+      "regex": [
+        "(?i)\\bsezione\\s+(?:da|compresa\\s+tra)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)?\\s*(?:[,;\\s]*a|[-]\\s*)\\s*\\d+(?:[.,]\\d+)?\\s*(?:cmq|cm²|cm2)\\b",
+        "(?i)\\bsezione\\s+(?:(?<!non\\s)superiore\\s+a|maggiore\\s+di|oltre)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b",
+        "(?i)\\bsezione\\s+(?:di|pari\\s+a)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b"
+      ],
+      "normalizers": [
+        "strip",
+        "comma_to_dot",
+        "to_unit:cm2"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "cm²",
+      "applies_to": {
+        "supercats": [
+          "Assistenze murarie"
+        ],
+        "cats": [
+          "Assistenze murarie alla posa di impianti"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "cm²"
+      },
+      "confidence": 0.71
+    },
+    {
+      "property_id": "assistenze_murarie.assistenze_murarie_alla_posa_di_impianti.sezione_max_cm2",
+      "regex": [
+        "(?i)\\bsezione\\s+(?:da|compresa\\s+tra)\\s*\\d+(?:[.,]\\d+)?\\s*(?:cmq|cm²|cm2)?\\s*(?:[,;\\s]*a|[-]\\s*)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b",
+        "(?i)\\b(?:sezione\\s+)?(?:ma\\s+)?non\\s+superiore\\s+a\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b",
+        "(?i)\\bsezione\\s+(?:fino\\s+a)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b",
+        "(?i)\\bsezione\\s+(?:di|pari\\s+a)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b"
+      ],
+      "normalizers": [
+        "strip",
+        "comma_to_dot",
+        "to_unit:cm2"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "cm²",
+      "applies_to": {
+        "supercats": [
+          "Assistenze murarie"
+        ],
+        "cats": [
+          "Assistenze murarie alla posa di impianti"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "cm²"
+      },
+      "confidence": 0.71
+    },
+    {
       "property_id": "opere_murarie.__global__.produttore",
       "regex": [
         "(?i)\\\\b(?:produttore|brand|marca|manufacturer)\\\\b\\\\s*[:=\\\\-]?\\\\s*(?P<val>(?!(?:(?:RAL(?:\\\\s*\\\\d{2,4})?|GK[BFI]|DOP|POE|EER|CE|UNI(?:\\\\s*EN)?(?:\\\\s*ISO)?(?:\\\\s*\\\\d{2,5}(?:[-/]?\\\\d{1,2})?)?|EN(?:\\\\s*ISO)?(?:\\\\s*\\\\d{2,5}(?:[-/]?\\\\d{1,2})?)?|EN\\\\s*AW(?:[-\\\\s]*\\\\d{2,5})?|NTC(?:\\\\s*\\\\d{4})?|ISO(?:\\\\s*\\\\d{3,5}(?:[-/]?\\\\d{1,2})?)?|DIN(?:\\\\s*\\\\d{3,5}(?:[-/]?\\\\d{1,2})?)?|CEI(?:\\\\s*\\\\d{3,5}(?:[-/]?\\\\d{1,2})?)?|Uw(?:\\\\s*[=≤]\\\\s*\\\\d(?:[.,]\\\\d+)?)?))\\\\b)[A-Z][A-Za-z0-9\\\\-\\\\s&]{2,60})\\\\b",
@@ -1760,6 +2783,90 @@
       "confidence": 0.73
     },
     {
+      "property_id": "opere_murarie.__global__.spessore_mm",
+      "regex": [
+        "(?i)\\bspessore\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bspess\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+        "(?i)\\bspessore\\s*:?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:centimetri|millimetri)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "to_number"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "supercats": [
+          "Opere murarie"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.72
+    },
+    {
+      "property_id": "opere_murarie.__global__.massa_volumica_kg_m3",
+      "regex": [
+        "(?i)\\bmassa\\s+volumica(?:\\s+lorda|\\s+media)?\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)(?:\\s*[-–]\\s*\\d{2,4}(?:[.,]\\d{1,3})?)?\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+        "(?i)\\bdensità\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)(?:\\s*[-–]\\s*\\d{2,4}(?:[.,]\\d{1,3})?)?\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+        "(?i)\\bdensita\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)(?:\\s*[-–]\\s*\\d{2,4}(?:[.,]\\d{1,3})?)?\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³",
+      "applies_to": {
+        "supercats": [
+          "Opere murarie"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "kg/m³"
+      },
+      "confidence": 0.71
+    },
+    {
+      "property_id": "opere_murarie.__global__.classe_ei",
+      "regex": [
+        "(?i)\\b(?:R?E\\.?\\s*I\\.?)\\s*(?P<val>15|20|30|45|60|90|120|180|240|360)\\b",
+        "(?i)\\bresistenza\\s+al\\s+fuoco\\s*[:=]?\\s*(?:R?E\\.?\\s*I\\.?)\\s*(?P<val>15|20|30|45|60|90|120|180|240|360)\\b",
+        "(?i)\\bfire\\s+resistance\\s*[:=]?\\s*(?:R?E\\.?\\s*I\\.?)\\s*(?P<val>15|20|30|45|60|90|120|180|240|360)\\b",
+        "(?i)\\bclasse\\s+(?P<val>15|20|30|45|60|90|120|180|240|360)\\s*minuti\\b"
+      ],
+      "normalizers": [
+        "to_ei_class",
+        "upper",
+        "strip",
+        "comma_to_dot"
+      ],
+      "tags": [
+        "fuoco"
+      ],
+      "unit": null,
+      "applies_to": {
+        "supercats": [
+          "Opere murarie"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {},
+      "confidence": 0.74
+    },
+    {
       "property_id": "opere_murarie.__global__.superficie_m2",
       "regex": [
         "(?i)\\b(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:m²|m2|mq\\.?|mq)\\b",
@@ -1821,6 +2928,93 @@
         "unit": "m³"
       },
       "confidence": 0.73
+    },
+    {
+      "property_id": "opere_murarie.blocchi_in_calcestruzzo_cellulare_aerato_autoclavato.fonoassorbenza_db",
+      "regex": [
+        "(?i)\\bfonoassorbenza\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*dB\\b",
+        "(?i)\\babbattimento\\s+acustico\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*dB\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "acustica"
+      ],
+      "unit": "dB",
+      "applies_to": {
+        "supercats": [
+          "Opere murarie"
+        ],
+        "cats": [
+          "Blocchi in calcestruzzo cellulare aerato autoclavato"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "dB"
+      },
+      "confidence": 0.78
+    },
+    {
+      "property_id": "opere_murarie.blocchi_in_calcestruzzo_cellulare_aerato_autoclavato.trasmittanza_termica_wm2k",
+      "regex": [
+        "(?i)\\btrasmittanza\\s+termica\\s*(?:pari\\s*a|=|:|<|<=)?\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,3})?)\\s*W\\s*/?\\s*m(?:²|2|q)\\s*K\\b",
+        "(?i)\\bU\\s*=\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,3})?)\\s*W\\s*/?\\s*m(?:²|2|q)\\s*K\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "termica"
+      ],
+      "unit": "W/m²K",
+      "applies_to": {
+        "supercats": [
+          "Opere murarie"
+        ],
+        "cats": [
+          "Blocchi in calcestruzzo cellulare aerato autoclavato"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "W/m²K"
+      },
+      "confidence": 0.77
+    },
+    {
+      "property_id": "opere_murarie.elementi_in_laterizio.trasmittanza_termica_wm2k",
+      "regex": [
+        "(?i)\\btrasmittanza\\s+termica\\s*(?:pari\\s*a|=|:|<|<=)?\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,3})?)\\s*W\\s*/?\\s*m(?:²|2|q)\\s*K\\b",
+        "(?i)\\bU\\s*=\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,3})?)\\s*W\\s*/?\\s*m(?:²|2|q)\\s*K\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_number"
+      ],
+      "tags": [
+        "termica"
+      ],
+      "unit": "W/m²K",
+      "applies_to": {
+        "supercats": [
+          "Opere murarie"
+        ],
+        "cats": [
+          "Elementi in laterizio"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "W/m²K"
+      },
+      "confidence": 0.77
     },
     {
       "property_id": "opere_da_cartongessista.__global__.produttore",
@@ -2032,6 +3226,220 @@
         "unit": "m³"
       },
       "confidence": 0.73
+    },
+    {
+      "property_id": "opere_da_cartongessista.__global__.spessore_totale_mm",
+      "regex": [
+        "(?i)(?:parete|controparete|setto|veletta|placcaggio|controsoffitto)[^\\n]{0,80}?\\bsp(?:essore)?\\.?\\s*(?:totale\\s*)?(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+        "(?i)\\bspessore\\s+totale\\s*(?:[:=])?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+        "(?i)\\bsp\\.?\\s*totale\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "strip"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "supercats": [
+          "Opere da cartongessista"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "opere_da_cartongessista.__global__.altezza_mm",
+      "regex": [
+        "(?i)\\bH\\.?\\s*(?:max\\s*)?(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+        "(?i)\\baltezza\\s*(?:massima\\s*)?(?:fino\\s+a\\s*)?(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+        "(?i)\\bh\\s*max\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "strip"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "supercats": [
+          "Opere da cartongessista"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.69
+    },
+    {
+      "property_id": "opere_da_cartongessista.__global__.orditura_metallica_spessore_mm",
+      "regex": [
+        "(?i)\\borditura\\s+metallica[^\\n]{0,40}?\\b(?:da|sp\\.?|spessore)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+        "(?i)\\bmono\\s+orditura\\s+metallica[^\\n]{0,40}?\\b(?:da|sp\\.?|spessore)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+        "(?i)\\bsottostruttura\\s+metallica[^\\n]{0,60}?\\b(?:sp\\.?|spessore|da)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "strip"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "supercats": [
+          "Opere da cartongessista"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.69
+    },
+    {
+      "property_id": "opere_da_cartongessista.__global__.passo_montanti_mm",
+      "regex": [
+        "(?i)\\bpasso(?:\\s+dei)?\\s+montanti(?:\\s+di)?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+        "(?i)\\binterasse(?:\\s+non\\s+superiore\\s+a)?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "strip"
+      ],
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "supercats": [
+          "Opere da cartongessista"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "opere_da_cartongessista.__global__.isolante_spessore_mm",
+      "regex": [
+        "(?i)\\bstrato\\s+isolante[^\\n]{0,60}?\\b(?:sp\\.?|spessore)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+        "(?i)\\bisolamento[^\\n]{0,60}?\\b(?:sp\\.?|spessore)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+        "(?i)\\blana\\s+minerale[^\\n]{0,60}?\\bsp\\.?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "to_unit:mm",
+        "strip"
+      ],
+      "tags": [
+        "materiale"
+      ],
+      "unit": "mm",
+      "applies_to": {
+        "supercats": [
+          "Opere da cartongessista"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "mm"
+      },
+      "confidence": 0.7
+    },
+    {
+      "property_id": "opere_da_cartongessista.__global__.isolante_densita_kg_m3",
+      "regex": [
+        "(?i)\\bdensit[àa]\\s*(?:=|:)?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:kg\\s*/\\s*m3|kg\\s*/\\s*mc|kg/m3|kg/mc|kg/m³)\\b",
+        "(?i)\\b(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:kg\\s*/\\s*m3|kg\\s*/\\s*mc|kg/m3|kg/mc|kg/m³)\\b(?=[^\\n]{0,20}?densit[àa])"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "strip"
+      ],
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³",
+      "applies_to": {
+        "supercats": [
+          "Opere da cartongessista"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "kg/m³"
+      },
+      "confidence": 0.68
+    },
+    {
+      "property_id": "opere_da_cartongessista.__global__.isolante_lambda_W_mK",
+      "regex": [
+        "(?i)\\b(?:λD?|lambda)\\s*(?:=|:)?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:W/mK|W\\s*/\\s*mK)\\b"
+      ],
+      "normalizers": [
+        "comma_to_dot",
+        "strip"
+      ],
+      "tags": [
+        "materiale"
+      ],
+      "unit": "W/mK",
+      "applies_to": {
+        "supercats": [
+          "Opere da cartongessista"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {
+        "unit": "W/mK"
+      },
+      "confidence": 0.65
+    },
+    {
+      "property_id": "opere_da_cartongessista.__global__.classe_reazione_fuoco",
+      "regex": [
+        "(?i)\\bEuroclasse\\s*(?P<val>[A-F](?:-[A-Z0-9,]+)?)\\b",
+        "(?i)\\bclasse\\s+(?P<val>A1|A2|B|B-s1,d0|B-s2,d0|B-s3,d0|C|C-s1,d0|C-s2,d0|D|E|F)\\b(?=[^\\n]{0,40}reazione\\s+al\\s+fuoco)"
+      ],
+      "normalizers": [
+        "upper",
+        "strip"
+      ],
+      "tags": [
+        "fuoco"
+      ],
+      "unit": null,
+      "applies_to": {
+        "supercats": [
+          "Opere da cartongessista"
+        ]
+      },
+      "examples": [],
+      "examples_negative": [],
+      "post_validations": {},
+      "confidence": 0.7
     },
     {
       "property_id": "opere_da_cartongessista.accessori_per_cartongessi.classe_ei",

--- a/data/properties/modular/Assistenze murarie/Assistenze murarie alla posa di impianti/extractors.json
+++ b/data/properties/modular/Assistenze murarie/Assistenze murarie alla posa di impianti/extractors.json
@@ -1,0 +1,59 @@
+[
+  {
+    "property_id": "assistenze_murarie.assistenze_murarie_alla_posa_di_impianti.sezione_min_cm2",
+    "regex": [
+      "(?i)\\bsezione\\s+(?:da|compresa\\s+tra)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)?\\s*(?:[,;\\s]*a|[-]\\s*)\\s*\\d+(?:[.,]\\d+)?\\s*(?:cmq|cm²|cm2)\\b",
+      "(?i)\\bsezione\\s+(?:(?<!non\\s)superiore\\s+a|maggiore\\s+di|oltre)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b",
+      "(?i)\\bsezione\\s+(?:di|pari\\s+a)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b"
+    ],
+    "normalizers": [
+      "strip",
+      "comma_to_dot",
+      "to_unit:cm2"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "cm²",
+    "applies_to": {
+      "cats": [
+        "Assistenze murarie alla posa di impianti"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "cm²"
+    },
+    "confidence": 0.71
+  },
+  {
+    "property_id": "assistenze_murarie.assistenze_murarie_alla_posa_di_impianti.sezione_max_cm2",
+    "regex": [
+      "(?i)\\bsezione\\s+(?:da|compresa\\s+tra)\\s*\\d+(?:[.,]\\d+)?\\s*(?:cmq|cm²|cm2)?\\s*(?:[,;\\s]*a|[-]\\s*)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b",
+      "(?i)\\b(?:sezione\\s+)?(?:ma\\s+)?non\\s+superiore\\s+a\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b",
+      "(?i)\\bsezione\\s+(?:fino\\s+a)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b",
+      "(?i)\\bsezione\\s+(?:di|pari\\s+a)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:cmq|cm²|cm2)\\b"
+    ],
+    "normalizers": [
+      "strip",
+      "comma_to_dot",
+      "to_unit:cm2"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "cm²",
+    "applies_to": {
+      "cats": [
+        "Assistenze murarie alla posa di impianti"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "cm²"
+    },
+    "confidence": 0.71
+  }
+]

--- a/data/properties/modular/Assistenze murarie/Assistenze murarie alla posa di impianti/registry.json
+++ b/data/properties/modular/Assistenze murarie/Assistenze murarie alla posa di impianti/registry.json
@@ -1,3 +1,26 @@
 {
-  "slots": {}
+  "slots": {
+    "sezione_min_cm2": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "cm²",
+      "expected_atoms": [
+        "atom_surface_m2_v2"
+      ]
+    },
+    "sezione_max_cm2": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "cm²",
+      "expected_atoms": [
+        "atom_surface_m2_v2"
+      ]
+    }
+  }
 }

--- a/data/properties/modular/Cantierizzazioni/Installazione cantiere/extractors.json
+++ b/data/properties/modular/Cantierizzazioni/Installazione cantiere/extractors.json
@@ -1,0 +1,35 @@
+[
+  {
+    "property_id": "cantierizzazioni.installazione_cantiere.dimensioni_cartello_mm",
+    "regex": [
+      "(?i)\\bcartello[^0-9]{0,80}?(?P<a>\\d{2,5})(?:\\s*(?P<unit1>mm|cm|m))?\\s*[x×X]\\s*(?P<b>\\d{2,5})(?:\\s*(?P<unit2>mm|cm|m))?\\b",
+      "(?i)\\bdimensioni?[^0-9]{0,40}?cartello[^0-9]{0,40}?(?P<a>\\d{2,5})(?:\\s*(?P<unit1>mm|cm|m))?\\s*[x×X]\\s*(?P<b>\\d{2,5})(?:\\s*(?P<unit2>mm|cm|m))?\\b"
+    ],
+    "normalizers": [
+      "normalize_dimensions_to_mm",
+      "validate_aspect_ratio",
+      "strip",
+      "comma_to_dot"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm×mm",
+    "applies_to": {
+      "supercats": [
+        "Cantierizzazioni"
+      ],
+      "cats": [
+        "Installazione cantiere"
+      ]
+    },
+    "examples": [
+      "Realizzazione di cartello di cantiere ... Dimensione di circa 200 x 140 cm"
+    ],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm×mm"
+    },
+    "confidence": 0.72
+  }
+]

--- a/data/properties/modular/Cantierizzazioni/Installazione cantiere/registry.json
+++ b/data/properties/modular/Cantierizzazioni/Installazione cantiere/registry.json
@@ -1,3 +1,15 @@
 {
-  "slots": {}
+  "slots": {
+    "dimensioni_cartello_mm": {
+      "type": "text",
+      "priority": 6,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm×mm",
+      "expected_atoms": [
+        "atom_formati_dims_v2"
+      ]
+    }
+  }
 }

--- a/data/properties/modular/Cantierizzazioni/Noli/extractors.json
+++ b/data/properties/modular/Cantierizzazioni/Noli/extractors.json
@@ -1,0 +1,135 @@
+[
+  {
+    "property_id": "cantierizzazioni.noli.altezza_operativa_m",
+    "regex": [
+      "(?i)\\baltezza(?:[^0-9]{0,40})?(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\b",
+      "(?i)\\baltezza\\s+(?:totale\\s+)?variabile\\s+da\\s+\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:m|mt|cm)\\s*(?:a|fino\\s+a)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\b",
+      "(?i)\\b(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\s+(?:di\\s+)?altezza\\b"
+    ],
+    "normalizers": [
+      "join_range",
+      "comma_to_dot",
+      "to_unit:m",
+      "strip"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "m",
+    "applies_to": {
+      "supercats": [
+        "Cantierizzazioni"
+      ],
+      "cats": [
+        "Noli"
+      ]
+    },
+    "examples": [
+      "Piattaforma telescopica articolata autocarrata ... altezza 30,00 m, sbraccio 15,00 m, portata 400 kg"
+    ],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "m"
+    },
+    "confidence": 0.74
+  },
+  {
+    "property_id": "cantierizzazioni.noli.sbraccio_operativo_m",
+    "regex": [
+      "(?i)\\bsbraccio(?:[^0-9]{0,30})?(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\b",
+      "(?i)\\b(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:m|mt|cm)\\s+(?:di\\s+)?sbraccio\\b"
+    ],
+    "normalizers": [
+      "join_range",
+      "comma_to_dot",
+      "to_unit:m",
+      "strip"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "m",
+    "applies_to": {
+      "supercats": [
+        "Cantierizzazioni"
+      ],
+      "cats": [
+        "Noli"
+      ]
+    },
+    "examples": [
+      "Piattaforma telescopica articolata autocarrata ... sbraccio 15,00 m"
+    ],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "m"
+    },
+    "confidence": 0.72
+  },
+  {
+    "property_id": "cantierizzazioni.noli.portata_massima_kg",
+    "regex": [
+      "(?i)\\bportata(?:[^0-9]{0,30})?(?P<val>\\d{1,6}(?:[.,]\\d{1,3})?)\\s*(?:kg|chilogrammi|t|tonnellate)\\b",
+      "(?i)\\b(?P<val>\\d{1,6}(?:[.,]\\d{1,3})?)\\s*(?:kg|chilogrammi|t|tonnellate)\\s+di\\s+portata\\b"
+    ],
+    "normalizers": [
+      "join_range",
+      "comma_to_dot",
+      "to_unit:kg",
+      "strip"
+    ],
+    "tags": [
+      "prestazioni"
+    ],
+    "unit": "kg",
+    "applies_to": {
+      "supercats": [
+        "Cantierizzazioni"
+      ],
+      "cats": [
+        "Noli"
+      ]
+    },
+    "examples": [
+      "Elevatore a cremagliera ... portata 1100 kg"
+    ],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "kg"
+    },
+    "confidence": 0.75
+  },
+  {
+    "property_id": "cantierizzazioni.noli.dimensioni_piattaforma_mm",
+    "regex": [
+      "(?i)\\bpiattaforma\\s*(?:di\\s+carico\\s*)?(?:dimensioni|misure|formato)\\s*(?:[:=]?\\s*)?(?P<a>\\d{2,5})(?:\\s*(?P<unit1>mm|cm|m))?\\s*[x×X]\\s*(?P<b>\\d{2,5})(?:\\s*(?P<unit2>mm|cm|m))?\\b",
+      "(?i)\\bdimensioni\\s*(?:della\\s+)?piattaforma\\s*(?:[:=]?\\s*)?(?P<a>\\d{2,5})(?:\\s*(?P<unit1>mm|cm|m))?\\s*[x×X]\\s*(?P<b>\\d{2,5})(?:\\s*(?P<unit2>mm|cm|m))?\\b"
+    ],
+    "normalizers": [
+      "normalize_dimensions_to_mm",
+      "validate_aspect_ratio",
+      "strip",
+      "comma_to_dot"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm×mm",
+    "applies_to": {
+      "supercats": [
+        "Cantierizzazioni"
+      ],
+      "cats": [
+        "Noli"
+      ]
+    },
+    "examples": [
+      "Elevatore a cremagliera ... piattaforma dimensioni 150x180 cm"
+    ],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm×mm"
+    },
+    "confidence": 0.73
+  }
+]

--- a/data/properties/modular/Cantierizzazioni/Noli/registry.json
+++ b/data/properties/modular/Cantierizzazioni/Noli/registry.json
@@ -1,3 +1,48 @@
 {
-  "slots": {}
+  "slots": {
+    "altezza_operativa_m": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "m",
+      "expected_atoms": [
+        "atom_length_m_v2"
+      ]
+    },
+    "sbraccio_operativo_m": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "m",
+      "expected_atoms": [
+        "atom_length_m_v2"
+      ]
+    },
+    "portata_massima_kg": {
+      "type": "float",
+      "priority": 9,
+      "tags": [
+        "prestazioni"
+      ],
+      "unit": "kg",
+      "expected_atoms": [
+        "atom_mass_kg_v2"
+      ]
+    },
+    "dimensioni_piattaforma_mm": {
+      "type": "text",
+      "priority": 6,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm×mm",
+      "expected_atoms": [
+        "atom_formati_dims_v2"
+      ]
+    }
+  }
 }

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Cappe di completamento/extractors.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Cappe di completamento/extractors.json
@@ -1,0 +1,161 @@
+[
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.spessore_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:medio\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Cappe di completamento"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.71
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.spessore_min_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:da|min(?:imo)?|variabile\\s+da)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:min(?:imo)?|min\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Cappe di completamento"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.spessore_max_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:fino\\s?a|max(?:imo)?|massimo|max\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:da\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*)(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Cappe di completamento"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.massa_volumica_kg_m3",
+    "regex": [
+      "(?i)\\bmassa\\s+volumica(?:\\s+nominale)?(?:\\s+in\\s+opera)?\\s*(?:pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+      "(?i)\\bdensit[àa]\\s*(?:in\\s+opera\\s*)?(?:circa\\s*|pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "materiale"
+    ],
+    "unit": "kg/m³",
+    "applies_to": {
+      "cats": [
+        "Cappe di completamento"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "kg/m³"
+    },
+    "confidence": 0.69
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.resistenza_compressione_N_mm2",
+    "regex": [
+      "(?i)\\bresistenza\\s+(?:media\\s+)?(?:a\\s+)?compressione(?:\\s+certificata)?\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|n/mm\\u00b2|mpa)\\b",
+      "(?i)\\bclasse\\s+di\\s+compressione\\s*(?:c|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|mpa)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "strutturale"
+    ],
+    "unit": "N/mm²",
+    "applies_to": {
+      "cats": [
+        "Cappe di completamento"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "N/mm²"
+    },
+    "confidence": 0.69
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.cappe_di_completamento.conducibilita_termica_W_mK",
+    "regex": [
+      "(?i)\\b(?:conducibilit[àa]\\s+termica|lambda|λ)\\s*(?:certificata\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1}(?:[.,]\\d{1,3})?)\\s*(?:w\\s*/?\\s*m?k)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "termica"
+    ],
+    "unit": "W/mK",
+    "applies_to": {
+      "cats": [
+        "Cappe di completamento"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "W/mK"
+    },
+    "confidence": 0.68
+  }
+]

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Cappe di completamento/registry.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Cappe di completamento/registry.json
@@ -1,3 +1,52 @@
 {
-  "slots": {}
+  "slots": {
+    "spessore_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "spessore_min_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "spessore_max_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "massa_volumica_kg_m3": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³"
+    },
+    "resistenza_compressione_N_mm2": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "N/mm²"
+    },
+    "conducibilita_termica_W_mK": {
+      "type": "float",
+      "priority": 6,
+      "tags": [
+        "termica"
+      ],
+      "unit": "W/mK"
+    }
+  }
 }

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Massetti alleggeriti/extractors.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Massetti alleggeriti/extractors.json
@@ -1,0 +1,160 @@
+[
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.spessore_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:medio\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Massetti alleggeriti"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.71
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.spessore_min_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:da|min(?:imo)?|variabile\\s+da)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:min(?:imo)?|min\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Massetti alleggeriti"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.spessore_max_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:fino\\s?a|max(?:imo)?|massimo|max\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:da\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*)(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Massetti alleggeriti"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.massa_volumica_kg_m3",
+    "regex": [
+      "(?i)\\bmassa\\s+volumica(?:\\s+nominale)?(?:\\s+in\\s+opera)?\\s*(?:pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+      "(?i)\\bdensit[àa]\\s*(?:in\\s+opera\\s*)?(?:circa\\s*|pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "materiale"
+    ],
+    "unit": "kg/m³",
+    "applies_to": {
+      "cats": [
+        "Massetti alleggeriti"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "kg/m³"
+    },
+    "confidence": 0.69
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.resistenza_compressione_N_mm2",
+    "regex": [
+      "(?i)\\bresistenza\\s+(?:media\\s+)?(?:a\\s+)?compressione(?:\\s+certificata)?\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|n/mm\\u00b2|mpa)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "strutturale"
+    ],
+    "unit": "N/mm²",
+    "applies_to": {
+      "cats": [
+        "Massetti alleggeriti"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "N/mm²"
+    },
+    "confidence": 0.69
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_alleggeriti.conducibilita_termica_W_mK",
+    "regex": [
+      "(?i)\\b(?:conducibilit[àa]\\s+termica|lambda|λ)\\s*(?:certificata\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1}(?:[.,]\\d{1,3})?)\\s*(?:w\\s*/?\\s*m?k)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "termica"
+    ],
+    "unit": "W/mK",
+    "applies_to": {
+      "cats": [
+        "Massetti alleggeriti"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "W/mK"
+    },
+    "confidence": 0.68
+  }
+]

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Massetti alleggeriti/registry.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Massetti alleggeriti/registry.json
@@ -1,3 +1,52 @@
 {
-  "slots": {}
+  "slots": {
+    "spessore_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "spessore_min_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "spessore_max_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "massa_volumica_kg_m3": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³"
+    },
+    "resistenza_compressione_N_mm2": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "N/mm²"
+    },
+    "conducibilita_termica_W_mK": {
+      "type": "float",
+      "priority": 6,
+      "tags": [
+        "termica"
+      ],
+      "unit": "W/mK"
+    }
+  }
 }

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Massetti pendenzati/extractors.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Massetti pendenzati/extractors.json
@@ -1,0 +1,135 @@
+[
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.spessore_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:variabile\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Massetti pendenzati"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.71
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.spessore_min_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:da|min(?:imo)?|variabile\\s+da)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:min(?:imo)?|min\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Massetti pendenzati"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.spessore_max_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:variabile\\s*fino\\s*a|fino\\s*a|max(?:imo)?|massimo|max\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:da\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*)(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Massetti pendenzati"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.dosaggio_cemento_kg_m3",
+    "regex": [
+      "(?i)\\b(?:dosat[oa]|dosaggio)\\s*(?:a\\s*)?(?:minimo\\s*)?(?P<val>\\d{2,4}(?:[.,]\\d{1,2})?)\\s*(?:kg)\\b[^\\n]{0,60}?\\b(?:per\\s*(?:m(?:c|3)|metro\\s+cubo))"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "materiale"
+    ],
+    "unit": "kg/m³",
+    "applies_to": {
+      "cats": [
+        "Massetti pendenzati"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "kg/m³"
+    },
+    "confidence": 0.68
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.massetti_pendenzati.resistenza_Rck_N_mm2",
+    "regex": [
+      "(?i)\\brck\\s*(?:=|:|pari\\s*a)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|n/mm\\u00b2|mpa)\\b",
+      "(?i)\\bresistenza\\s+maggiore\\s+di\\s*rck\\s*=\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:n/mm2|mpa)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "strutturale"
+    ],
+    "unit": "N/mm²",
+    "applies_to": {
+      "cats": [
+        "Massetti pendenzati"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "N/mm²"
+    },
+    "confidence": 0.68
+  }
+]

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Massetti pendenzati/registry.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Massetti pendenzati/registry.json
@@ -1,3 +1,44 @@
 {
-  "slots": {}
+  "slots": {
+    "spessore_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "spessore_min_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "spessore_max_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "dosaggio_cemento_kg_m3": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³"
+    },
+    "resistenza_Rck_N_mm2": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "N/mm²"
+    }
+  }
 }

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Sottofondi pavimentazioni/extractors.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Sottofondi pavimentazioni/extractors.json
@@ -1,0 +1,164 @@
+[
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.spessore_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:medio\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Sottofondi pavimentazioni"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.71
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.spessore_min_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:da|min(?:imo)?|variabile\\s+da)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:min(?:imo)?|min\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Sottofondi pavimentazioni"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.spessore_max_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:fino\\s?a|max(?:imo)?|massimo|max\\.)\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:da\\s*\\d{1,3}(?:[.,]\\d{1,2})?\\s*(?:mm|cm|m)\\s*(?:-|a|to)\\s*)(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Sottofondi pavimentazioni"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.massa_volumica_kg_m3",
+    "regex": [
+      "(?i)\\bmassa\\s+volumica(?:\\s+nominale)?(?:\\s+in\\s+opera)?\\s*(?:pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+      "(?i)\\bdensit[àa]\\s*(?:in\\s+opera\\s*)?(?:circa\\s*|pari\\s*a|=|:|<|>){0,1}\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "materiale"
+    ],
+    "unit": "kg/m³",
+    "applies_to": {
+      "cats": [
+        "Sottofondi pavimentazioni"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "kg/m³"
+    },
+    "confidence": 0.69
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.rete_diametro_mm",
+    "regex": [
+      "(?i)\\bdiametro\\s*(?:di|Ø|ø)?\\s*(?:ø)?\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b",
+      "(?i)\\bØ\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b",
+      "(?i)\\b(?:tondini|barre)\\s+di\\s+diametro\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "strutturale"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Sottofondi pavimentazioni"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.68
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.sottofondi_pavimentazioni.rete_maglia_mm",
+    "regex": [
+      "(?i)\\bmaglia\\s*(?P<a>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*[x×]\\s*(?P<b>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm)\\b",
+      "(?i)\\bmaglia\\s*(?P<a>\\d{1,3})\\s*[x×]\\s*(?P<b>\\d{1,3})\\s*cm\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "normalize_dimensions_to_mm",
+      "strip"
+    ],
+    "tags": [
+      "strutturale"
+    ],
+    "unit": "mm×mm",
+    "applies_to": {
+      "cats": [
+        "Sottofondi pavimentazioni"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm×mm"
+    },
+    "confidence": 0.68
+  }
+]

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Sottofondi pavimentazioni/registry.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Sottofondi pavimentazioni/registry.json
@@ -1,3 +1,52 @@
 {
-  "slots": {}
+  "slots": {
+    "spessore_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "spessore_min_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "spessore_max_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "massa_volumica_kg_m3": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³"
+    },
+    "rete_diametro_mm": {
+      "type": "float",
+      "priority": 6,
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm"
+    },
+    "rete_maglia_mm": {
+      "type": "text",
+      "priority": 6,
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm×mm"
+    }
+  }
 }

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Teli di separazione/extractors.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Teli di separazione/extractors.json
@@ -1,0 +1,80 @@
+[
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.teli_di_separazione.spessore_mm",
+    "regex": [
+      "(?i)\\bsp(?:essore|\\.)\\s*(?:nominale\\s*)?(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Teli di separazione"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.69
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.teli_di_separazione.sovrapposizione_min_cm",
+    "regex": [
+      "(?i)\\bsovrappost[oi]\\s+(?:sulle\\s+giunture\\s+)?(?:di|per)\\s+(?:almeno\\s+)?(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*cm\\b",
+      "(?i)\\bgiunti\\s+sovrapposti\\s+di\\s+(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*cm\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "cm",
+    "applies_to": {
+      "cats": [
+        "Teli di separazione"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "cm"
+    },
+    "confidence": 0.68
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.teli_di_separazione.peso_areico_kg_m2",
+    "regex": [
+      "(?i)\\bpeso\\s*(?:areico\\s*)?(?P<val>\\d{1,3}(?:[.,]\\d{1,3})?)\\s*(?:kg\\s*/?\\s*m(?:q|2|²))\\b",
+      "(?i)\\bpeso\\s*(?:kg\\s*/?\\s*m(?:q|2|²))\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,3})?)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "materiale"
+    ],
+    "unit": "kg/m²",
+    "applies_to": {
+      "cats": [
+        "Teli di separazione"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "kg/m²"
+    },
+    "confidence": 0.68
+  }
+]

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Teli di separazione/registry.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Teli di separazione/registry.json
@@ -1,3 +1,28 @@
 {
-  "slots": {}
+  "slots": {
+    "spessore_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "sovrapposizione_min_cm": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "cm"
+    },
+    "peso_areico_kg_m2": {
+      "type": "float",
+      "priority": 6,
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m²"
+    }
+  }
 }

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Vespai aerati/extractors.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Vespai aerati/extractors.json
@@ -1,0 +1,106 @@
+[
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.vespai_aerati.soletta_spessore_min_mm",
+    "regex": [
+      "(?i)\\bsoletta[^\\n]{0,60}?sp(?:essore|\\.)\\s*(?:min(?:imo)?|almeno|min\\.)\\s*(?:di\\s*)?(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "strutturale"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Vespai aerati"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.68
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.vespai_aerati.casseri_altezza_mm",
+    "regex": [
+      "(?i)\\b(?:casseri|elementi\\s+modulari|vespaio)\\b[^\\n]{0,60}?altezza\\s*(?:media\\s*)?(?:di|pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Vespai aerati"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.68
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.vespai_aerati.rete_diametro_mm",
+    "regex": [
+      "(?i)\\brete[^\\n]{0,40}?diametro\\s*(?:di|Ø|ø)?\\s*(?:ø)?\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b",
+      "(?i)\\bØ\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,2})?)\\s*mm\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "strutturale"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "cats": [
+        "Vespai aerati"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.68
+  },
+  {
+    "property_id": "massetti_sottofondi_drenaggi_vespai.vespai_aerati.rete_maglia_mm",
+    "regex": [
+      "(?i)\\brete[^\\n]{0,40}?maglia\\s*(?P<a>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*[x×]\\s*(?P<b>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "normalize_dimensions_to_mm",
+      "strip"
+    ],
+    "tags": [
+      "strutturale"
+    ],
+    "unit": "mm×mm",
+    "applies_to": {
+      "cats": [
+        "Vespai aerati"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm×mm"
+    },
+    "confidence": 0.68
+  }
+]

--- a/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Vespai aerati/registry.json
+++ b/data/properties/modular/Massetti, sottofondi, drenaggi, vespai/Vespai aerati/registry.json
@@ -1,3 +1,36 @@
 {
-  "slots": {}
+  "slots": {
+    "soletta_spessore_min_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm"
+    },
+    "casseri_altezza_mm": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "rete_diametro_mm": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm"
+    },
+    "rete_maglia_mm": {
+      "type": "text",
+      "priority": 7,
+      "tags": [
+        "strutturale"
+      ],
+      "unit": "mm×mm"
+    }
+  }
 }

--- a/data/properties/modular/Opere da cartongessista/_global/extractors.json
+++ b/data/properties/modular/Opere da cartongessista/_global/extractors.json
@@ -209,5 +209,219 @@
       "unit": "m³"
     },
     "confidence": 0.73
+  },
+  {
+    "property_id": "opere_da_cartongessista.__global__.spessore_totale_mm",
+    "regex": [
+      "(?i)(?:parete|controparete|setto|veletta|placcaggio|controsoffitto)[^\\n]{0,80}?\\bsp(?:essore)?\\.?\\s*(?:totale\\s*)?(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+      "(?i)\\bspessore\\s+totale\\s*(?:[:=])?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+      "(?i)\\bsp\\.?\\s*totale\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "strip"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "supercats": [
+        "Opere da cartongessista"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "opere_da_cartongessista.__global__.altezza_mm",
+    "regex": [
+      "(?i)\\bH\\.?\\s*(?:max\\s*)?(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+      "(?i)\\baltezza\\s*(?:massima\\s*)?(?:fino\\s+a\\s*)?(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+      "(?i)\\bh\\s*max\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "strip"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "supercats": [
+        "Opere da cartongessista"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.69
+  },
+  {
+    "property_id": "opere_da_cartongessista.__global__.orditura_metallica_spessore_mm",
+    "regex": [
+      "(?i)\\borditura\\s+metallica[^\\n]{0,40}?\\b(?:da|sp\\.?|spessore)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+      "(?i)\\bmono\\s+orditura\\s+metallica[^\\n]{0,40}?\\b(?:da|sp\\.?|spessore)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+      "(?i)\\bsottostruttura\\s+metallica[^\\n]{0,60}?\\b(?:sp\\.?|spessore|da)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "strip"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "supercats": [
+        "Opere da cartongessista"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.69
+  },
+  {
+    "property_id": "opere_da_cartongessista.__global__.passo_montanti_mm",
+    "regex": [
+      "(?i)\\bpasso(?:\\s+dei)?\\s+montanti(?:\\s+di)?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+      "(?i)\\binterasse(?:\\s+non\\s+superiore\\s+a)?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "strip"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "supercats": [
+        "Opere da cartongessista"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.68
+  },
+  {
+    "property_id": "opere_da_cartongessista.__global__.isolante_spessore_mm",
+    "regex": [
+      "(?i)\\bstrato\\s+isolante[^\\n]{0,60}?\\b(?:sp\\.?|spessore)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+      "(?i)\\bisolamento[^\\n]{0,60}?\\b(?:sp\\.?|spessore)\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b",
+      "(?i)\\blana\\s+minerale[^\\n]{0,60}?\\bsp\\.?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(mm|cm|m)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "strip"
+    ],
+    "tags": [
+      "materiale"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "supercats": [
+        "Opere da cartongessista"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.7
+  },
+  {
+    "property_id": "opere_da_cartongessista.__global__.isolante_densita_kg_m3",
+    "regex": [
+      "(?i)\\bdensit[àa]\\s*(?:=|:)?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:kg\\s*/\\s*m3|kg\\s*/\\s*mc|kg/m3|kg/mc|kg/m³)\\b",
+      "(?i)\\b(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:kg\\s*/\\s*m3|kg\\s*/\\s*mc|kg/m3|kg/mc|kg/m³)\\b(?=[^\\n]{0,20}?densit[àa])"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "strip"
+    ],
+    "tags": [
+      "materiale"
+    ],
+    "unit": "kg/m³",
+    "applies_to": {
+      "supercats": [
+        "Opere da cartongessista"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "kg/m³"
+    },
+    "confidence": 0.68
+  },
+  {
+    "property_id": "opere_da_cartongessista.__global__.isolante_lambda_W_mK",
+    "regex": [
+      "(?i)\\b(?:λD?|lambda)\\s*(?:=|:)?\\s*(?P<val>\\d+(?:[.,]\\d+)?)\\s*(?:W/mK|W\\s*/\\s*mK)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "strip"
+    ],
+    "tags": [
+      "materiale"
+    ],
+    "unit": "W/mK",
+    "applies_to": {
+      "supercats": [
+        "Opere da cartongessista"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "W/mK"
+    },
+    "confidence": 0.65
+  },
+  {
+    "property_id": "opere_da_cartongessista.__global__.classe_reazione_fuoco",
+    "regex": [
+      "(?i)\\bEuroclasse\\s*(?P<val>[A-F](?:-[A-Z0-9,]+)?)\\b",
+      "(?i)\\bclasse\\s+(?P<val>A1|A2|B|B-s1,d0|B-s2,d0|B-s3,d0|C|C-s1,d0|C-s2,d0|D|E|F)\\b(?=[^\\n]{0,40}reazione\\s+al\\s+fuoco)"
+    ],
+    "normalizers": [
+      "upper",
+      "strip"
+    ],
+    "tags": [
+      "fuoco"
+    ],
+    "unit": null,
+    "applies_to": {
+      "supercats": [
+        "Opere da cartongessista"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {},
+    "confidence": 0.7
   }
 ]

--- a/data/properties/modular/Opere da cartongessista/_global/registry.json
+++ b/data/properties/modular/Opere da cartongessista/_global/registry.json
@@ -69,6 +69,69 @@
       "expected_atoms": [
         "atom_volume_m3_v2"
       ]
+    },
+    "spessore_totale_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "altezza_mm": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "orditura_metallica_spessore_mm": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "passo_montanti_mm": {
+      "type": "float",
+      "priority": 6,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "isolante_spessore_mm": {
+      "type": "float",
+      "priority": 6,
+      "tags": [
+        "materiale"
+      ],
+      "unit": "mm"
+    },
+    "isolante_densita_kg_m3": {
+      "type": "float",
+      "priority": 6,
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³"
+    },
+    "isolante_lambda_W_mK": {
+      "type": "float",
+      "priority": 5,
+      "tags": [
+        "materiale"
+      ],
+      "unit": "W/mK"
+    },
+    "classe_reazione_fuoco": {
+      "type": "text",
+      "priority": 6,
+      "tags": [
+        "fuoco"
+      ]
     }
   }
 }

--- a/data/properties/modular/Opere murarie/Blocchi in calcestruzzo cellulare aerato autoclavato/extractors.json
+++ b/data/properties/modular/Opere murarie/Blocchi in calcestruzzo cellulare aerato autoclavato/extractors.json
@@ -1,0 +1,60 @@
+[
+  {
+    "property_id": "opere_murarie.blocchi_in_calcestruzzo_cellulare_aerato_autoclavato.fonoassorbenza_db",
+    "regex": [
+      "(?i)\\bfonoassorbenza\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*dB\\b",
+      "(?i)\\babbattimento\\s+acustico\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*dB\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "acustica"
+    ],
+    "unit": "dB",
+    "applies_to": {
+      "supercats": [
+        "Opere murarie"
+      ],
+      "cats": [
+        "Blocchi in calcestruzzo cellulare aerato autoclavato"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "dB"
+    },
+    "confidence": 0.78
+  },
+  {
+    "property_id": "opere_murarie.blocchi_in_calcestruzzo_cellulare_aerato_autoclavato.trasmittanza_termica_wm2k",
+    "regex": [
+      "(?i)\\btrasmittanza\\s+termica\\s*(?:pari\\s*a|=|:|<|<=)?\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,3})?)\\s*W\\s*/?\\s*m(?:²|2|q)\\s*K\\b",
+      "(?i)\\bU\\s*=\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,3})?)\\s*W\\s*/?\\s*m(?:²|2|q)\\s*K\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "termica"
+    ],
+    "unit": "W/m²K",
+    "applies_to": {
+      "supercats": [
+        "Opere murarie"
+      ],
+      "cats": [
+        "Blocchi in calcestruzzo cellulare aerato autoclavato"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "W/m²K"
+    },
+    "confidence": 0.77
+  }
+]

--- a/data/properties/modular/Opere murarie/Blocchi in calcestruzzo cellulare aerato autoclavato/registry.json
+++ b/data/properties/modular/Opere murarie/Blocchi in calcestruzzo cellulare aerato autoclavato/registry.json
@@ -1,3 +1,23 @@
 {
-  "slots": {}
+  "slots": {
+    "fonoassorbenza_dB": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "acustica"
+      ],
+      "unit": "dB"
+    },
+    "trasmittanza_termica_Wm2K": {
+      "type": "float",
+      "priority": 6,
+      "tags": [
+        "termica"
+      ],
+      "unit": "W/m²K",
+      "expected_atoms": [
+        "atom_u_values_v2"
+      ]
+    }
+  }
 }

--- a/data/properties/modular/Opere murarie/Elementi in laterizio/extractors.json
+++ b/data/properties/modular/Opere murarie/Elementi in laterizio/extractors.json
@@ -1,0 +1,31 @@
+[
+  {
+    "property_id": "opere_murarie.elementi_in_laterizio.trasmittanza_termica_wm2k",
+    "regex": [
+      "(?i)\\btrasmittanza\\s+termica\\s*(?:pari\\s*a|=|:|<|<=)?\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,3})?)\\s*W\\s*/?\\s*m(?:²|2|q)\\s*K\\b",
+      "(?i)\\bU\\s*=\\s*(?P<val>\\d{1,2}(?:[.,]\\d{1,3})?)\\s*W\\s*/?\\s*m(?:²|2|q)\\s*K\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "termica"
+    ],
+    "unit": "W/m²K",
+    "applies_to": {
+      "supercats": [
+        "Opere murarie"
+      ],
+      "cats": [
+        "Elementi in laterizio"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "W/m²K"
+    },
+    "confidence": 0.77
+  }
+]

--- a/data/properties/modular/Opere murarie/Elementi in laterizio/registry.json
+++ b/data/properties/modular/Opere murarie/Elementi in laterizio/registry.json
@@ -1,3 +1,15 @@
 {
-  "slots": {}
+  "slots": {
+    "trasmittanza_termica_Wm2K": {
+      "type": "float",
+      "priority": 6,
+      "tags": [
+        "termica"
+      ],
+      "unit": "W/m²K",
+      "expected_atoms": [
+        "atom_u_values_v2"
+      ]
+    }
+  }
 }

--- a/data/properties/modular/Opere murarie/_global/extractors.json
+++ b/data/properties/modular/Opere murarie/_global/extractors.json
@@ -209,5 +209,89 @@
       "unit": "m³"
     },
     "confidence": 0.73
+  },
+  {
+    "property_id": "opere_murarie.__global__.spessore_mm",
+    "regex": [
+      "(?i)\\bspessore\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bsp\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bspess\\.?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:mm|cm|m)\\b",
+      "(?i)\\bspessore\\s*:?\\s*(?P<val>\\d{1,3}(?:[.,]\\d{1,2})?)\\s*(?:centimetri|millimetri)\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_unit:mm",
+      "to_number"
+    ],
+    "tags": [
+      "geometria"
+    ],
+    "unit": "mm",
+    "applies_to": {
+      "supercats": [
+        "Opere murarie"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "mm"
+    },
+    "confidence": 0.72
+  },
+  {
+    "property_id": "opere_murarie.__global__.massa_volumica_kg_m3",
+    "regex": [
+      "(?i)\\bmassa\\s+volumica(?:\\s+lorda|\\s+media)?\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)(?:\\s*[-–]\\s*\\d{2,4}(?:[.,]\\d{1,3})?)?\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+      "(?i)\\bdensità\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)(?:\\s*[-–]\\s*\\d{2,4}(?:[.,]\\d{1,3})?)?\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b",
+      "(?i)\\bdensita\\s*(?:pari\\s*a|=|:)?\\s*(?P<val>\\d{2,4}(?:[.,]\\d{1,3})?)(?:\\s*[-–]\\s*\\d{2,4}(?:[.,]\\d{1,3})?)?\\s*(?:kg\\s*/?\\s*m(?:c|³|3))\\b"
+    ],
+    "normalizers": [
+      "comma_to_dot",
+      "to_number"
+    ],
+    "tags": [
+      "materiale"
+    ],
+    "unit": "kg/m³",
+    "applies_to": {
+      "supercats": [
+        "Opere murarie"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {
+      "unit": "kg/m³"
+    },
+    "confidence": 0.71
+  },
+  {
+    "property_id": "opere_murarie.__global__.classe_ei",
+    "regex": [
+      "(?i)\\b(?:R?E\\.?\\s*I\\.?)\\s*(?P<val>15|20|30|45|60|90|120|180|240|360)\\b",
+      "(?i)\\bresistenza\\s+al\\s+fuoco\\s*[:=]?\\s*(?:R?E\\.?\\s*I\\.?)\\s*(?P<val>15|20|30|45|60|90|120|180|240|360)\\b",
+      "(?i)\\bfire\\s+resistance\\s*[:=]?\\s*(?:R?E\\.?\\s*I\\.?)\\s*(?P<val>15|20|30|45|60|90|120|180|240|360)\\b",
+      "(?i)\\bclasse\\s+(?P<val>15|20|30|45|60|90|120|180|240|360)\\s*minuti\\b"
+    ],
+    "normalizers": [
+      "to_ei_class",
+      "upper",
+      "strip",
+      "comma_to_dot"
+    ],
+    "tags": [
+      "fuoco"
+    ],
+    "unit": null,
+    "applies_to": {
+      "supercats": [
+        "Opere murarie"
+      ]
+    },
+    "examples": [],
+    "examples_negative": [],
+    "post_validations": {},
+    "confidence": 0.74
   }
 ]

--- a/data/properties/modular/Opere murarie/_global/registry.json
+++ b/data/properties/modular/Opere murarie/_global/registry.json
@@ -48,6 +48,32 @@
         "atom_dimensione_LxHxP_v2"
       ]
     },
+    "spessore_mm": {
+      "type": "float",
+      "priority": 8,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm"
+    },
+    "massa_volumica_kg_m3": {
+      "type": "float",
+      "priority": 7,
+      "tags": [
+        "materiale"
+      ],
+      "unit": "kg/m³"
+    },
+    "classe_EI": {
+      "type": "text",
+      "priority": 7,
+      "tags": [
+        "fuoco"
+      ],
+      "expected_atoms": [
+        "atom_ei_rei_v2"
+      ]
+    },
     "superficie_m2": {
       "type": "float",
       "priority": 5,

--- a/data/properties/modular/metadata/_global/registry.json
+++ b/data/properties/modular/metadata/_global/registry.json
@@ -1,3 +1,74 @@
 {
-  "slots": {}
+  "slots": {
+    "produttore": {
+      "type": "text",
+      "priority": 10,
+      "tags": [
+        "brand"
+      ],
+      "expected_atoms": [
+        "atom_brand_generic_v2"
+      ]
+    },
+    "modello": {
+      "type": "text",
+      "priority": 9,
+      "tags": [
+        "brand",
+        "collezione"
+      ],
+      "expected_atoms": [
+        "atom_model_variants_it_v2"
+      ]
+    },
+    "norme_riferimento": {
+      "type": "text",
+      "priority": 6,
+      "tags": [
+        "normativa"
+      ],
+      "expected_atoms": [
+        "atom_std_generic_v2",
+        "atom_dm_date_v2",
+        "atom_dpr_v2",
+        "atom_dlgs_v2",
+        "atom_en_13501_1_v2",
+        "atom_uni_en_1279_v2"
+      ]
+    },
+    "dimensioni_lxh_mm": {
+      "type": "text",
+      "priority": 6,
+      "tags": [
+        "geometria"
+      ],
+      "unit": "mm×mm",
+      "expected_atoms": [
+        "atom_formati_dims_v2",
+        "atom_dimensione_LxHxP_v2"
+      ]
+    },
+    "superficie_m2": {
+      "type": "float",
+      "priority": 5,
+      "tags": [
+        "quantita"
+      ],
+      "unit": "m²",
+      "expected_atoms": [
+        "atom_surface_m2_v2"
+      ]
+    },
+    "volume_m3": {
+      "type": "float",
+      "priority": 5,
+      "tags": [
+        "quantita"
+      ],
+      "unit": "m³",
+      "expected_atoms": [
+        "atom_volume_m3_v2"
+      ]
+    }
+  }
 }

--- a/data/properties/registry.json
+++ b/data/properties/registry.json
@@ -55,6 +55,32 @@
             "atom_dimensione_LxHxP_v2"
           ]
         },
+        "spessore_mm": {
+          "type": "float",
+          "priority": 8,
+          "tags": [
+            "geometria"
+          ],
+          "unit": "mm"
+        },
+        "massa_volumica_kg_m3": {
+          "type": "float",
+          "priority": 7,
+          "tags": [
+            "materiale"
+          ],
+          "unit": "kg/m³"
+        },
+        "classe_EI": {
+          "type": "text",
+          "priority": 7,
+          "tags": [
+            "fuoco"
+          ],
+          "expected_atoms": [
+            "atom_ei_rei_v2"
+          ]
+        },
         "superficie_m2": {
           "type": "float",
           "priority": 5,
@@ -76,6 +102,69 @@
           "expected_atoms": [
             "atom_volume_m3_v2"
           ]
+        },
+        "spessore_totale_mm": {
+          "type": "float",
+          "priority": 8,
+          "tags": [
+            "geometria"
+          ],
+          "unit": "mm"
+        },
+        "altezza_mm": {
+          "type": "float",
+          "priority": 7,
+          "tags": [
+            "geometria"
+          ],
+          "unit": "mm"
+        },
+        "orditura_metallica_spessore_mm": {
+          "type": "float",
+          "priority": 7,
+          "tags": [
+            "geometria"
+          ],
+          "unit": "mm"
+        },
+        "passo_montanti_mm": {
+          "type": "float",
+          "priority": 6,
+          "tags": [
+            "geometria"
+          ],
+          "unit": "mm"
+        },
+        "isolante_spessore_mm": {
+          "type": "float",
+          "priority": 6,
+          "tags": [
+            "materiale"
+          ],
+          "unit": "mm"
+        },
+        "isolante_densita_kg_m3": {
+          "type": "float",
+          "priority": 6,
+          "tags": [
+            "materiale"
+          ],
+          "unit": "kg/m³"
+        },
+        "isolante_lambda_W_mK": {
+          "type": "float",
+          "priority": 5,
+          "tags": [
+            "materiale"
+          ],
+          "unit": "W/mK"
+        },
+        "classe_reazione_fuoco": {
+          "type": "text",
+          "priority": 6,
+          "tags": [
+            "fuoco"
+          ]
         }
       }
     },
@@ -84,10 +173,67 @@
         "slots": {}
       },
       "Installazione cantiere": {
-        "slots": {}
+        "slots": {
+          "dimensioni_cartello_mm": {
+            "type": "text",
+            "priority": 6,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm×mm",
+            "expected_atoms": [
+              "atom_formati_dims_v2"
+            ]
+          }
+        }
       },
       "Noli": {
-        "slots": {}
+        "slots": {
+          "altezza_operativa_m": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "m",
+            "expected_atoms": [
+              "atom_length_m_v2"
+            ]
+          },
+          "sbraccio_operativo_m": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "m",
+            "expected_atoms": [
+              "atom_length_m_v2"
+            ]
+          },
+          "portata_massima_kg": {
+            "type": "float",
+            "priority": 9,
+            "tags": [
+              "prestazioni"
+            ],
+            "unit": "kg",
+            "expected_atoms": [
+              "atom_mass_kg_v2"
+            ]
+          },
+          "dimensioni_piattaforma_mm": {
+            "type": "text",
+            "priority": 6,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm×mm",
+            "expected_atoms": [
+              "atom_formati_dims_v2"
+            ]
+          }
+        }
       },
       "Pulizie di cantiere": {
         "slots": {}
@@ -174,7 +320,30 @@
         "slots": {}
       },
       "Assistenze murarie alla posa di impianti": {
-        "slots": {}
+        "slots": {
+          "sezione_min_cm2": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "cm²",
+            "expected_atoms": [
+              "atom_surface_m2_v2"
+            ]
+          },
+          "sezione_max_cm2": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "cm²",
+            "expected_atoms": [
+              "atom_surface_m2_v2"
+            ]
+          }
+        }
       }
     }
   },
@@ -255,13 +424,45 @@
     },
     "categories": {
       "Blocchi in calcestruzzo cellulare aerato autoclavato": {
-        "slots": {}
+        "slots": {
+          "fonoassorbenza_dB": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "acustica"
+            ],
+            "unit": "dB"
+          },
+          "trasmittanza_termica_Wm2K": {
+            "type": "float",
+            "priority": 6,
+            "tags": [
+              "termica"
+            ],
+            "unit": "W/m²K",
+            "expected_atoms": [
+              "atom_u_values_v2"
+            ]
+          }
+        }
       },
       "Blocchi in calcestruzzo vibrocompresso": {
         "slots": {}
       },
       "Elementi in laterizio": {
-        "slots": {}
+        "slots": {
+          "trasmittanza_termica_Wm2K": {
+            "type": "float",
+            "priority": 6,
+            "tags": [
+              "termica"
+            ],
+            "unit": "W/m²K",
+            "expected_atoms": [
+              "atom_u_values_v2"
+            ]
+          }
+        }
       },
       "Murature in altri materiali": {
         "slots": {}
@@ -856,22 +1057,268 @@
     },
     "categories": {
       "Cappe di completamento": {
-        "slots": {}
+        "slots": {
+          "spessore_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "spessore_min_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "spessore_max_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "massa_volumica_kg_m3": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "materiale"
+            ],
+            "unit": "kg/m³"
+          },
+          "resistenza_compressione_N_mm2": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "strutturale"
+            ],
+            "unit": "N/mm²"
+          },
+          "conducibilita_termica_W_mK": {
+            "type": "float",
+            "priority": 6,
+            "tags": [
+              "termica"
+            ],
+            "unit": "W/mK"
+          }
+        }
       },
       "Massetti alleggeriti": {
-        "slots": {}
+        "slots": {
+          "spessore_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "spessore_min_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "spessore_max_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "massa_volumica_kg_m3": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "materiale"
+            ],
+            "unit": "kg/m³"
+          },
+          "resistenza_compressione_N_mm2": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "strutturale"
+            ],
+            "unit": "N/mm²"
+          },
+          "conducibilita_termica_W_mK": {
+            "type": "float",
+            "priority": 6,
+            "tags": [
+              "termica"
+            ],
+            "unit": "W/mK"
+          }
+        }
       },
       "Massetti pendenzati": {
-        "slots": {}
+        "slots": {
+          "spessore_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "spessore_min_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "spessore_max_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "dosaggio_cemento_kg_m3": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "materiale"
+            ],
+            "unit": "kg/m³"
+          },
+          "resistenza_Rck_N_mm2": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "strutturale"
+            ],
+            "unit": "N/mm²"
+          }
+        }
       },
       "Sottofondi pavimentazioni": {
-        "slots": {}
+        "slots": {
+          "spessore_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "spessore_min_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "spessore_max_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "massa_volumica_kg_m3": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "materiale"
+            ],
+            "unit": "kg/m³"
+          },
+          "rete_diametro_mm": {
+            "type": "float",
+            "priority": 6,
+            "tags": [
+              "strutturale"
+            ],
+            "unit": "mm"
+          },
+          "rete_maglia_mm": {
+            "type": "text",
+            "priority": 6,
+            "tags": [
+              "strutturale"
+            ],
+            "unit": "mm×mm"
+          }
+        }
       },
       "Teli di separazione": {
-        "slots": {}
+        "slots": {
+          "spessore_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "sovrapposizione_min_cm": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "cm"
+          },
+          "peso_areico_kg_m2": {
+            "type": "float",
+            "priority": 6,
+            "tags": [
+              "materiale"
+            ],
+            "unit": "kg/m²"
+          }
+        }
       },
       "Vespai aerati": {
-        "slots": {}
+        "slots": {
+          "soletta_spessore_min_mm": {
+            "type": "float",
+            "priority": 8,
+            "tags": [
+              "strutturale"
+            ],
+            "unit": "mm"
+          },
+          "casseri_altezza_mm": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "geometria"
+            ],
+            "unit": "mm"
+          },
+          "rete_diametro_mm": {
+            "type": "float",
+            "priority": 7,
+            "tags": [
+              "strutturale"
+            ],
+            "unit": "mm"
+          },
+          "rete_maglia_mm": {
+            "type": "text",
+            "priority": 7,
+            "tags": [
+              "strutturale"
+            ],
+            "unit": "mm×mm"
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary
- define slots for the massetti, sottofondi, drenaggi e vespai categories covering thickness, density, mechanical and thermal metrics in their modular registries
- implement category-specific regex extractors for cappe, massetti alleggeriti/pendenzati, sottofondi, teli and vespai to capture the recurring corpus values
- propagate the new massetti property set into the packed registry and extractor bundle for downstream consumers

## Testing
- pytest -q tests/test_data_properties.py

------
https://chatgpt.com/codex/tasks/task_e_68d5638efdc4832295a3346373dbb978