### PR TITLE
Document property extraction results for full dataset test run

### DIFF
--- a/docs/property_extraction_test.md
+++ b/docs/property_extraction_test.md
@@ -1,0 +1,110 @@
+# Property Extraction Test Report
+
+## Sample per category
+```
+robimb sample-categories --dataset data/train/classification/raw/dataset.jsonl --output outputs/dataset_per_category.jsonl
+```
+
+### CLI Output
+```
+{
+  "output": "outputs/dataset_per_category.jsonl",
+  "num_records": 146,
+  "category_field": "cat"
+}
+```
+
+## Property extraction on sampled dataset
+```
+robimb convert --train-file outputs/dataset_per_category.jsonl --ontology data/wbs/ontology.json --label-maps outputs/per_category/label_maps.json --out-dir outputs/per_category
+```
+
+### CLI Output
+```
+{
+  "train_dataset": "outputs/per_category/train_processed.jsonl",
+  "val_dataset": "outputs/per_category/val_processed.jsonl",
+  "label_maps": "outputs/per_category/label_maps.json",
+  "mask_matrix": "outputs/per_category/mask_matrix.npy",
+  "mask_report": "outputs/per_category/mask_report.json",
+  "reports_dir": "outputs/per_category/reports"
+}
+```
+
+## Outputs
+- `outputs/dataset_per_category.jsonl`
+- `outputs/per_category/train_processed.jsonl`
+- `outputs/per_category/val_processed.jsonl`
+- `outputs/per_category/label_maps.json`
+- `outputs/per_category/mask_matrix.npy`
+- `outputs/per_category/mask_report.json`
+- `outputs/per_category/reports/`
+
+## Dataset Summary
+```
+{
+  "train": {
+    "num_records": 116,
+    "avg_text_length": 782.0948275862069,
+    "median_text_length": 647.0,
+    "p95_text_length": 1871.0
+  },
+  "val": {
+    "num_records": 30,
+    "avg_text_length": 727.4333333333333,
+    "median_text_length": 585.0,
+    "p95_text_length": 1498.1499999999999
+  }
+}
+```
+
+## Property extraction on full training dataset
+```
+robimb convert --train-file data/train/classification/raw/dataset.jsonl --ontology data/wbs/ontology.json --label-maps outputs/label_maps.json --out-dir outputs
+```
+
+### CLI Output
+```
+{
+  "train_dataset": "outputs/train_processed.jsonl",
+  "val_dataset": "outputs/val_processed.jsonl",
+  "label_maps": "outputs/label_maps.json",
+  "mask_matrix": "outputs/mask_matrix.npy",
+  "mask_report": "outputs/mask_report.json",
+  "reports_dir": "outputs/reports"
+}
+```
+
+### Dataset Summary
+```
+{
+  "train": {
+    "num_records": 39280,
+    "avg_text_length": 847.1959521384929,
+    "median_text_length": 640.0,
+    "p95_text_length": 2320.0
+  },
+  "val": {
+    "num_records": 9821,
+    "avg_text_length": 851.1460136442317,
+    "median_text_length": 643.0,
+    "p95_text_length": 2367.0
+  }
+}
+```
+
+### Property extraction metrics
+- Train set records with extracted properties: 28 106 / 39 280 (71.6%)
+- Validation set records with extracted properties: 7 007 / 9 821 (71.3%)
+- Most common extracted property slots (train):
+  1. `opere_da_serramentista.__global__.modello` (4 333 matches)
+  2. `apparecchi_sanitari_e_accessori.__global__.modello` (2 998 matches)
+  3. `opere_da_serramentista.__global__.dimensioni_lxh_mm` (2 802 matches)
+  4. `controsoffitti.__global__.modello` (2 763 matches)
+  5. `opere_di_pavimentazione.__global__.modello` (2 477 matches)
+- Most common extracted property slots (validation):
+  1. `opere_da_serramentista.__global__.modello` (1 075 matches)
+  2. `apparecchi_sanitari_e_accessori.__global__.modello` (716 matches)
+  3. `opere_da_serramentista.__global__.dimensioni_lxh_mm` (683 matches)
+  4. `controsoffitti.__global__.modello` (662 matches)
+  5. `opere_di_pavimentazione.__global__.modello` (659 matches)

--- a/src/robimb/utils/data_utils.py
+++ b/src/robimb/utils/data_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections import OrderedDict
 from pathlib import Path
 import unicodedata
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
@@ -388,6 +389,7 @@ __all__ = [
     "prepare_mlm_corpus",
     "create_or_load_label_maps",
     "build_mask_and_report",
+    "sample_one_record_per_category",
 ]
 
 
@@ -398,6 +400,54 @@ def load_jsonl_to_df(path: str | Path) -> pd.DataFrame:
             if line.strip():
                 rows.append(json.loads(line))
     return pd.DataFrame(rows)
+
+
+def sample_one_record_per_category(
+    path: str | Path,
+    *,
+    category_field: str = "cat",
+) -> List[Dict[str, Any]]:
+    """Return the first occurrence for each category found in ``path``.
+
+    Parameters
+    ----------
+    path:
+        JSONL file containing the dataset to scan.
+    category_field:
+        Field that identifies the category column. Defaults to ``"cat"`` which
+        is how the training dataset encodes category labels.
+
+    Returns
+    -------
+    list of dict
+        The sampled records preserving the original order of appearance.
+    """
+
+    dataset_path = Path(path)
+    if not dataset_path.exists():
+        raise FileNotFoundError(f"Dataset non trovato: {dataset_path}")
+
+    samples: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+    with dataset_path.open("r", encoding="utf-8") as handle:
+        for line_no, raw in enumerate(handle, start=1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                row = json.loads(raw)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                raise ValueError(f"Riga {line_no}: JSON non valido") from exc
+
+            category = row.get(category_field)
+            if isinstance(category, str) and category and category not in samples:
+                samples[category] = row
+
+    if not samples:
+        raise ValueError(
+            f"Nessuna categoria trovata usando il campo '{category_field}' in {dataset_path}"
+        )
+
+    return list(samples.values())
 
 
 def create_or_load_label_maps(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 """Smoke tests for the consolidated Typer CLI."""
+import json
+
 from typer.testing import CliRunner
 
 from robimb.cli.main import app
@@ -19,3 +21,36 @@ def test_version_option() -> None:
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
     assert "robimb" in result.stdout
+
+
+def test_sample_categories_command(tmp_path) -> None:
+    dataset = tmp_path / "dataset.jsonl"
+    rows = [
+        {"text": "Parete A", "super": "Strutture", "cat": "Pareti"},
+        {"text": "Parete B", "super": "Strutture", "cat": "Pareti"},
+        {"text": "Solaio", "super": "Strutture", "cat": "Solai"},
+    ]
+    with dataset.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+    output = tmp_path / "sampled.jsonl"
+    result = runner.invoke(
+        app,
+        [
+            "sample-categories",
+            "--dataset",
+            str(dataset),
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0
+    content = output.read_text(encoding="utf-8").strip().splitlines()
+    assert len(content) == 2
+
+    parsed = [json.loads(line) for line in content]
+    categories = {entry["cat"] for entry in parsed}
+    assert categories == {"Pareti", "Solai"}
+    assert parsed[0]["text"] == "Parete A"


### PR DESCRIPTION
## Summary
- document the full dataset property-extraction conversion run, including the CLI output and generated artifacts
- capture dataset length statistics from the generated reports and surface property coverage metrics for train and validation splits

## Testing
- robimb convert --train-file data/train/classification/raw/dataset.jsonl --ontology data/wbs/ontology.json --label-maps outputs/label_maps.json --out-dir outputs

------
https://chatgpt.com/codex/tasks/task_e_68d65a27e2d88322a172e6d96bead1c7