### PR TITLE
Add extraction router with LLM adapter and registry postprocessing

### DIFF
--- a/src/robimb/extraction/__init__.py
+++ b/src/robimb/extraction/__init__.py
@@ -2,7 +2,13 @@
 
 from .dsl import ExtractorsPack, PatternSpec, PatternSpecs
 from .engine import Pattern, dry_run, extract_properties
+from .formats import ExtractionCandidate, ExtractionResult, StageResult
+from .llm_adapter import SchemaField, StructuredLLMAdapter
 from .normalizers import BUILTIN_NORMALIZERS, Normalizer, NormalizerFactory, build_normalizer
+from .postprocess import PostProcessResult, apply_postprocess
+from .router import ExtractionRouter, RouterOutput
+from .rules import run_rules_stage
+from .span_tagger import SpanTagger, SpanTaggerOutput, build_stage
 
 __all__ = [
     "ExtractorsPack",
@@ -15,4 +21,17 @@ __all__ = [
     "Normalizer",
     "NormalizerFactory",
     "build_normalizer",
+    "ExtractionCandidate",
+    "ExtractionResult",
+    "StageResult",
+    "SchemaField",
+    "StructuredLLMAdapter",
+    "PostProcessResult",
+    "apply_postprocess",
+    "ExtractionRouter",
+    "RouterOutput",
+    "run_rules_stage",
+    "SpanTagger",
+    "SpanTaggerOutput",
+    "build_stage",
 ]

--- a/src/robimb/extraction/formats.py
+++ b/src/robimb/extraction/formats.py
@@ -1,0 +1,102 @@
+"""Common data structures shared across extraction stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+__all__ = [
+    "ExtractionCandidate",
+    "StageResult",
+    "ExtractionResult",
+]
+
+
+@dataclass
+class ExtractionCandidate:
+    """A single value produced by one stage of the extraction pipeline."""
+
+    property_id: str
+    value: Any
+    confidence: Optional[float] = None
+    stage: str = ""
+    provenance: Optional[str] = None
+    metadata: Mapping[str, Any] | None = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the candidate."""
+
+        payload: Dict[str, Any] = {
+            "property_id": self.property_id,
+            "value": self.value,
+            "stage": self.stage,
+        }
+        if self.confidence is not None:
+            payload["confidence"] = float(self.confidence)
+        if self.provenance is not None:
+            payload["provenance"] = self.provenance
+        if self.metadata is not None:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass
+class StageResult:
+    """Container tracking the candidates yielded by a single stage."""
+
+    stage: str
+    candidates: List[ExtractionCandidate] = field(default_factory=list)
+    extra: Mapping[str, Any] | None = None
+
+    def add(self, candidate: ExtractionCandidate) -> None:
+        self.candidates.append(candidate)
+
+    def by_property(self) -> Dict[str, List[ExtractionCandidate]]:
+        mapping: Dict[str, List[ExtractionCandidate]] = {}
+        for candidate in self.candidates:
+            bucket = mapping.setdefault(candidate.property_id, [])
+            bucket.append(candidate)
+        return mapping
+
+
+@dataclass
+class ExtractionResult:
+    """Aggregate view over all the stages executed by the router."""
+
+    stages: List[StageResult] = field(default_factory=list)
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        self._priority = {stage.stage: idx for idx, stage in enumerate(self.stages)}
+
+    def iter_candidates(self) -> Iterable[ExtractionCandidate]:
+        for stage in self.stages:
+            yield from stage.candidates
+
+    def by_property(self) -> Dict[str, List[ExtractionCandidate]]:
+        mapping: Dict[str, List[ExtractionCandidate]] = {}
+        for candidate in self.iter_candidates():
+            mapping.setdefault(candidate.property_id, []).append(candidate)
+        return mapping
+
+    def best_by_property(self) -> Dict[str, ExtractionCandidate]:
+        """Return the preferred candidate for each property."""
+
+        best: Dict[str, ExtractionCandidate] = {}
+        priority = self._priority
+        for property_id, candidates in self.by_property().items():
+            sorted_candidates = sorted(
+                candidates,
+                key=lambda cand: (
+                    priority.get(cand.stage, len(priority)),
+                    -(cand.confidence if cand.confidence is not None else 0.0),
+                ),
+            )
+            if sorted_candidates:
+                best[property_id] = sorted_candidates[0]
+        return best
+
+    def as_value_mapping(self) -> Dict[str, Any]:
+        """Expose the values of the preferred candidates."""
+
+        return {prop: candidate.value for prop, candidate in self.best_by_property().items()}
+

--- a/src/robimb/extraction/llm_adapter.py
+++ b/src/robimb/extraction/llm_adapter.py
@@ -1,0 +1,112 @@
+"""Rigid JSON adapter used by the router to interface LLM stages."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+from .formats import ExtractionCandidate, StageResult
+
+__all__ = ["SchemaField", "StructuredLLMAdapter"]
+
+
+@dataclass
+class SchemaField:
+    """Definition of a single slot expected from the language model."""
+
+    type: str
+    description: Optional[str] = None
+
+    def render(self, name: str) -> str:
+        desc = f" - {self.description}" if self.description else ""
+        return f"- {name}: {self.type}{desc}"
+
+
+class StructuredLLMAdapter:
+    """Compose prompts and parse JSON adhering to the provided schema."""
+
+    def __init__(
+        self,
+        schema: Mapping[str, SchemaField | Mapping[str, Any] | str],
+        *,
+        stage: str = "L0",
+    ) -> None:
+        self.stage = stage
+        self.schema: Dict[str, SchemaField] = {}
+        for name, spec in schema.items():
+            if isinstance(spec, SchemaField):
+                self.schema[name] = spec
+            elif isinstance(spec, Mapping):
+                self.schema[name] = SchemaField(
+                    type=str(spec.get("type", "string")),
+                    description=(str(spec.get("description")) if spec.get("description") else None),
+                )
+            else:
+                self.schema[name] = SchemaField(type=str(spec))
+
+    def build_prompt(self, text: str, *, extra_instructions: Optional[str] = None) -> str:
+        header = (
+            "Estrai le seguenti proprietà dal testo fornito. "
+            "Rispondi esclusivamente con un JSON valido. "
+            "Ogni chiave deve restituire un oggetto con campi 'value' e opzionalmente 'confidence' (0-1)."
+        )
+        lines = [header]
+        if extra_instructions:
+            lines.append(extra_instructions)
+        lines.append("Schema previsto:")
+        for name, field in self.schema.items():
+            lines.append(field.render(name))
+        lines.append("\nTesto:\n" + text.strip())
+        lines.append(
+            "\nOutput JSON di esempio: {\"property\": {\"value\": \"...\", \"confidence\": 0.7}}"
+        )
+        return "\n".join(lines)
+
+    def _parse_payload(self, payload: Any, property_id: str) -> tuple[Any, Optional[float]]:
+        if isinstance(payload, Mapping):
+            value = payload.get("value")
+            confidence = payload.get("confidence")
+        else:
+            value = payload
+            confidence = None
+        if confidence is not None:
+            try:
+                confidence = float(confidence)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Confidenza non valida per {property_id}: {confidence}") from exc
+            confidence = max(0.0, min(1.0, confidence))
+        return value, confidence
+
+    def parse_response(self, response: str) -> Dict[str, Dict[str, Any]]:
+        try:
+            data = json.loads(response)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ValueError("Risposta LLM non è un JSON valido") from exc
+        if not isinstance(data, Mapping):
+            raise ValueError("La risposta dell'LLM deve essere un oggetto JSON")
+
+        parsed: Dict[str, Dict[str, Any]] = {}
+        for name in self.schema:
+            if name not in data:
+                continue
+            value, confidence = self._parse_payload(data[name], name)
+            parsed[name] = {"value": value, "confidence": confidence}
+        return parsed
+
+    def build_stage(self, response: str) -> StageResult:
+        parsed = self.parse_response(response)
+        stage = StageResult(stage=self.stage)
+        for property_id, payload in parsed.items():
+            stage.add(
+                ExtractionCandidate(
+                    property_id=property_id,
+                    value=payload.get("value"),
+                    confidence=payload.get("confidence"),
+                    stage=self.stage,
+                    provenance="llm:structured",
+                    metadata={"source": "llm"},
+                )
+            )
+        return stage
+

--- a/src/robimb/extraction/postprocess.py
+++ b/src/robimb/extraction/postprocess.py
@@ -1,0 +1,81 @@
+"""Final normalisation and validation hooks shared across router clients."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+from ..registry import CategoryDefinition, validate
+
+__all__ = ["PostProcessResult", "apply_postprocess"]
+
+NUMERIC_TYPES = {"float", "int", "number"}
+BOOL_TYPES = {"bool", "boolean"}
+
+
+@dataclass
+class PostProcessResult:
+    values: Dict[str, Any]
+    issues: Optional[list[Dict[str, Any]]] = None
+
+
+def _coerce_numeric(value: Any) -> Any:
+    if isinstance(value, (int, float)):
+        return value
+    try:
+        return float(str(value).replace(",", "."))
+    except Exception:
+        return value
+
+
+def _coerce_boolean(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "si", "sì", "yes", "1"}:
+            return True
+        if lowered in {"false", "no", "0"}:
+            return False
+    return value
+
+
+def _apply_schema(values: MutableMapping[str, Any], category: CategoryDefinition) -> None:
+    for property_id, slot in category.slots.items():
+        if property_id not in values:
+            continue
+        value = values[property_id]
+        slot_type = slot.type or ""
+        if slot_type in NUMERIC_TYPES:
+            if isinstance(value, list):
+                values[property_id] = [_coerce_numeric(item) for item in value]
+            else:
+                values[property_id] = _coerce_numeric(value)
+        elif slot_type in BOOL_TYPES:
+            if isinstance(value, list):
+                values[property_id] = [_coerce_boolean(item) for item in value]
+            else:
+                values[property_id] = _coerce_boolean(value)
+
+
+def apply_postprocess(
+    values: Mapping[str, Any],
+    *,
+    category: Optional[CategoryDefinition] = None,
+    validators: Optional[Mapping[str, Any]] = None,
+    category_label: str = "",
+    context: Optional[Mapping[str, Any]] = None,
+    cat_entry: Optional[Mapping[str, Any]] = None,
+) -> PostProcessResult:
+    """Apply schema-driven normalisation and validator rules."""
+
+    normalized: Dict[str, Any] = dict(values)
+    if category is not None:
+        _apply_schema(normalized, category)
+
+    issues: Optional[list[Dict[str, Any]]] = None
+    if validators is not None:
+        issues = validate(category_label, normalized, context or {}, validators, cat_entry=cat_entry)
+
+    return PostProcessResult(values=normalized, issues=issues)
+

--- a/src/robimb/extraction/router.py
+++ b/src/robimb/extraction/router.py
@@ -1,0 +1,214 @@
+"""High level orchestrator coordinating all extraction stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Set
+
+from .formats import ExtractionResult, StageResult
+from .llm_adapter import StructuredLLMAdapter
+from .postprocess import PostProcessResult, apply_postprocess
+from .rules import run_rules_stage
+from .span_tagger import SpanTagger
+
+__all__ = ["ExtractionRouter", "RouterOutput"]
+
+
+def _normalize_category_labels(category: Any) -> Sequence[str]:
+    if category is None:
+        return []
+    if isinstance(category, str):
+        return [category]
+    if isinstance(category, Mapping):
+        value = category.get("label")
+        return [value] if value else []
+    labels: list[str] = []
+    try:
+        iterator = iter(category)
+    except TypeError:
+        return labels
+    for item in iterator:
+        labels.extend(_normalize_category_labels(item))
+    return labels
+
+
+def _extractor_property_ids(pack: Any) -> Set[str]:
+    cache = getattr(pack, "_extractor_property_ids", None)
+    if cache is None:
+        extractors = getattr(pack, "extractors", {})
+        patterns = extractors.get("patterns", []) if isinstance(extractors, Mapping) else []
+        cache = {
+            item.get("property_id")
+            for item in patterns
+            if isinstance(item, Mapping) and item.get("property_id")
+        }
+        setattr(pack, "_extractor_property_ids", cache)
+    return set(cache)
+
+
+def _category_property_index(pack: Any) -> Dict[str, Set[str]]:
+    cache = getattr(pack, "_category_property_index", None)
+    if cache is not None:
+        return cache
+    index: Dict[str, Set[str]] = {}
+    groups = pack.registry.get("groups", {}) if getattr(pack, "registry", None) else {}
+
+    def collect_from_groups(group_ids: Iterable[str]) -> Set[str]:
+        props: Set[str] = set()
+        for gid in group_ids or []:
+            group = groups.get(gid)
+            if isinstance(group, Mapping):
+                props.update(item for item in group.get("properties", []) if isinstance(item, str))
+        return props
+
+    catmap = getattr(pack, "catmap", {})
+    mappings = catmap.get("mappings", []) if isinstance(catmap, Mapping) else []
+    for mapping in mappings:
+        if not isinstance(mapping, Mapping):
+            continue
+        allowed: Set[str] = set()
+        for key in ("props_required", "props_recommended"):
+            allowed.update(item for item in mapping.get(key, []) if isinstance(item, str))
+        allowed.update(collect_from_groups(mapping.get("groups_required", [])))
+        allowed.update(collect_from_groups(mapping.get("groups_recommended", [])))
+        keynote = mapping.get("keynote_mapping", {})
+        if isinstance(keynote, Mapping):
+            for target in keynote.values():
+                if isinstance(target, str) and target:
+                    allowed.add(target)
+        cat_label = str(mapping.get("cat_label", "")).lower()
+        cat_id = str(mapping.get("cat_id", "")).lower()
+        frozen = set(allowed)
+        if cat_label:
+            index[cat_label] = frozen
+        if cat_id:
+            index[cat_id] = frozen
+    setattr(pack, "_category_property_index", index)
+    return index
+
+
+def _find_cat_entry(pack: Any, cat_label: str) -> Optional[Mapping[str, Any]]:
+    catmap = getattr(pack, "catmap", {})
+    mappings = catmap.get("mappings", []) if isinstance(catmap, Mapping) else []
+    for mapping in mappings:
+        if not isinstance(mapping, Mapping):
+            continue
+        if str(mapping.get("cat_label", "")).lower() == cat_label.lower():
+            return mapping
+    return None
+
+
+def _resolve_category(pack: Any, category_label: str):
+    models = getattr(pack, "category_models", None)
+    if isinstance(models, Mapping):
+        for definition in models.values():
+            candidate = getattr(definition, "category_label", None) or getattr(definition, "category", None)
+            if isinstance(candidate, str) and candidate.lower() == category_label.lower():
+                return definition
+    categories = getattr(pack, "categories", {})
+    if isinstance(categories, Mapping):
+        for definition in categories.values():
+            candidate = getattr(definition, "category_label", None) or getattr(definition, "category", None)
+            if isinstance(candidate, str) and candidate.lower() == category_label.lower():
+                return definition
+    return None
+
+
+@dataclass
+class RouterOutput:
+    text: str
+    categories: Sequence[str]
+    extraction: ExtractionResult
+    postprocess: PostProcessResult
+
+    def values(self) -> Dict[str, Any]:
+        return dict(self.postprocess.values)
+
+
+class ExtractionRouter:
+    """Compose the multi-stage extraction pipeline."""
+
+    def __init__(
+        self,
+        pack: Any,
+        *,
+        span_tagger: Optional[SpanTagger] = None,
+        llm_adapter: Optional[StructuredLLMAdapter] = None,
+    ) -> None:
+        self.pack = pack
+        self.span_tagger = span_tagger
+        self.llm_adapter = llm_adapter
+
+    def allowed_properties(self, categories: Any) -> Optional[Set[str]]:
+        labels = {label.strip() for label in _normalize_category_labels(categories) if label}
+        if not labels:
+            return None
+        index = _category_property_index(self.pack)
+        collected: Set[str] = set()
+        for label in labels:
+            key = label.lower()
+            collected.update(index.get(key, set()))
+        return collected if collected else None
+
+    def build_llm_prompt(self, text: str, *, extra_instructions: Optional[str] = None) -> str:
+        if self.llm_adapter is None:
+            raise RuntimeError("LLM adapter non configurato")
+        return self.llm_adapter.build_prompt(text, extra_instructions=extra_instructions)
+
+    def extract(
+        self,
+        text: str,
+        *,
+        categories: Any = None,
+        context: Optional[Mapping[str, Any]] = None,
+        target_tags: Optional[Iterable[str]] = None,
+        llm_response: Optional[str] = None,
+    ) -> RouterOutput:
+        allowed = self.allowed_properties(categories)
+        stages: list[StageResult] = []
+        extractor_ids = _extractor_property_ids(self.pack)
+        allowed_for_rules = None
+        if allowed is not None:
+            allowed_for_rules = allowed.intersection(extractor_ids)
+        stages.append(
+            run_rules_stage(
+                text,
+                getattr(self.pack, "extractors", {}),
+                allowed_properties=allowed_for_rules,
+                target_tags=target_tags,
+            )
+        )
+        labels = _normalize_category_labels(categories)
+        if self.span_tagger is not None:
+            stages.append(
+                self.span_tagger(
+                    text,
+                    allowed_properties=list(allowed) if allowed else None,
+                    categories=labels,
+                )
+            )
+        if self.llm_adapter is not None and llm_response:
+            stages.append(self.llm_adapter.build_stage(llm_response))
+
+        extraction = ExtractionResult(stages)
+        best_values = extraction.as_value_mapping()
+
+        primary_label = labels[0] if labels else ""
+        category_def = _resolve_category(self.pack, primary_label) if primary_label else None
+        cat_entry = _find_cat_entry(self.pack, primary_label) if primary_label else None
+        postprocess = apply_postprocess(
+            best_values,
+            category=category_def,
+            validators=getattr(self.pack, "validators", None),
+            category_label=primary_label,
+            context=context,
+            cat_entry=cat_entry,
+        )
+
+        return RouterOutput(
+            text=text,
+            categories=labels,
+            extraction=extraction,
+            postprocess=postprocess,
+        )
+

--- a/src/robimb/extraction/rules.py
+++ b/src/robimb/extraction/rules.py
@@ -1,0 +1,72 @@
+"""Stage R0: rule based extraction powered by the regex engine."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, MutableMapping, Optional
+
+from .dsl import ExtractorsPack
+from .engine import dry_run, extract_properties
+from .formats import ExtractionCandidate, StageResult
+
+__all__ = ["run_rules_stage"]
+
+
+def _confidence_for(property_id: str, regex: str, extractors_pack: ExtractorsPack) -> Optional[float]:
+    for pattern in extractors_pack.get("patterns", []):
+        if pattern.get("property_id") != property_id:
+            continue
+        regexes = pattern.get("regex", [])
+        if isinstance(regexes, Iterable) and regex in regexes:
+            raw_conf = pattern.get("confidence")
+            if isinstance(raw_conf, (int, float)):
+                return float(raw_conf)
+    return None
+
+
+def run_rules_stage(
+    text: str,
+    extractors_pack: ExtractorsPack,
+    *,
+    allowed_properties: Optional[Iterable[str]] = None,
+    target_tags: Optional[Iterable[str]] = None,
+) -> StageResult:
+    """Apply the legacy regex engine and capture provenance for each match."""
+
+    extracted = extract_properties(
+        text,
+        extractors_pack,
+        allowed_properties=allowed_properties,
+        target_tags=target_tags,
+    )
+    debug = dry_run(
+        text,
+        extractors_pack,
+        allowed_properties=allowed_properties,
+        target_tags=target_tags,
+    )
+    matches = debug.get("matches", []) if isinstance(debug, Mapping) else []
+    matches_by_prop: MutableMapping[str, list[Mapping[str, object]]] = {}
+    for item in matches:
+        property_id = str(item.get("property_id"))
+        matches_by_prop.setdefault(property_id, []).append(item)
+
+    stage = StageResult(stage="R0", extra={"matches": matches})
+    for property_id, value in extracted.items():
+        bucket = matches_by_prop.get(property_id) or []
+        provenance = "rules:regex"
+        confidence = None
+        metadata = bucket[0] if bucket else None
+        if bucket:
+            confidence = _confidence_for(property_id, str(bucket[0].get("regex")), extractors_pack)
+        stage.add(
+            ExtractionCandidate(
+                property_id=property_id,
+                value=value,
+                confidence=confidence,
+                stage="R0",
+                provenance=provenance,
+                metadata=metadata,
+            )
+        )
+    return stage
+

--- a/src/robimb/extraction/span_tagger.py
+++ b/src/robimb/extraction/span_tagger.py
@@ -1,0 +1,87 @@
+"""Stage R1: interface for span tagger or classifier based property inference."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
+
+from .formats import ExtractionCandidate, StageResult
+
+__all__ = ["SpanTagger", "SpanTaggerOutput", "build_stage"]
+
+
+PredictionLike = Mapping[str, Any]
+
+
+@dataclass
+class SpanTaggerOutput:
+    """Raw prediction returned by a downstream span tagger."""
+
+    property_id: str
+    value: Any
+    confidence: Optional[float] = None
+    provenance: Optional[str] = None
+    metadata: Mapping[str, Any] | None = None
+
+    @classmethod
+    def from_payload(cls, payload: PredictionLike) -> "SpanTaggerOutput":
+        return cls(
+            property_id=str(payload.get("property_id")),
+            value=payload.get("value"),
+            confidence=payload.get("confidence"),
+            provenance=payload.get("provenance"),
+            metadata=payload.get("metadata"),
+        )
+
+
+def build_stage(predictions: Iterable[PredictionLike]) -> StageResult:
+    """Convert raw predictions to a :class:`StageResult`."""
+
+    stage = StageResult(stage="R1")
+    for payload in predictions:
+        candidate = SpanTaggerOutput.from_payload(payload)
+        if not candidate.property_id:
+            continue
+        stage.add(
+            ExtractionCandidate(
+                property_id=candidate.property_id,
+                value=candidate.value,
+                confidence=(float(candidate.confidence) if candidate.confidence is not None else None),
+                stage="R1",
+                provenance=candidate.provenance or "span_tagger",
+                metadata=candidate.metadata,
+            )
+        )
+    return stage
+
+
+class SpanTagger:
+    """Lightweight adapter wrapping any callable exposing span predictions."""
+
+    def __init__(
+        self,
+        predictor: Callable[[str, Optional[Sequence[str]]], Iterable[PredictionLike]],
+    ) -> None:
+        self._predictor = predictor
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        allowed_properties: Optional[Sequence[str]] = None,
+        categories: Optional[Sequence[str]] = None,
+    ) -> StageResult:
+        predictions = self._predictor(text, allowed_properties)
+        filtered: Iterable[PredictionLike]
+        if allowed_properties:
+            allowed = {prop for prop in allowed_properties}
+
+            def _filter(payload: PredictionLike) -> bool:
+                pid = str(payload.get("property_id"))
+                return pid in allowed if pid else False
+
+            filtered = (payload for payload in predictions if _filter(payload))
+        else:
+            filtered = predictions
+        return build_stage(filtered)
+

--- a/src/robimb/inference/predict_properties.py
+++ b/src/robimb/inference/predict_properties.py
@@ -1,115 +1,16 @@
+"""Compatibility layer exposing the router from the classic inference API."""
+
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Optional, Sequence, Set
+from typing import Any, Mapping
 
-from ..extraction import extract_properties
+from ..extraction import ExtractionRouter
 
-
-def _normalize_category_labels(category: Any) -> Sequence[str]:
-    """Return a flat list of category labels from various inputs."""
-
-    if category is None:
-        return []
-    if isinstance(category, str):
-        return [category]
-    if isinstance(category, dict):
-        value = category.get("label")
-        return [value] if value else []
-
-    labels: list[str] = []
-    try:
-        iterator = iter(category)
-    except TypeError:
-        return labels
-
-    for item in iterator:
-        labels.extend(_normalize_category_labels(item))
-    return labels
+__all__ = ["predict_properties"]
 
 
-def _extractor_property_ids(pack) -> Set[str]:
-    """Return the set of property ids defined in the extractors pack."""
+def predict_properties(text: str, pack: Any, categories: Any) -> Mapping[str, Any]:
+    router = ExtractionRouter(pack)
+    output = router.extract(text, categories=categories)
+    return output.postprocess.values
 
-    cache = getattr(pack, "_extractor_property_ids", None)
-    if cache is None:
-        cache = {
-            item.get("property_id")
-            for item in pack.extractors.get("patterns", [])
-            if item.get("property_id")
-        }
-        setattr(pack, "_extractor_property_ids", cache)
-    return cache
-
-
-def _category_property_index(pack) -> Dict[str, Set[str]]:
-    """Build an index mapping category identifiers to allowed property ids."""
-
-    cache = getattr(pack, "_category_property_index", None)
-    if cache is not None:
-        return cache
-
-    index: Dict[str, Set[str]] = {}
-    groups = pack.registry.get("groups", {}) if getattr(pack, "registry", None) else {}
-
-    def collect_from_groups(group_ids: Iterable[str]) -> Set[str]:
-        props: Set[str] = set()
-        for gid in group_ids or []:
-            group = groups.get(gid)
-            if group:
-                props.update(group.get("properties", []))
-        return props
-
-    for mapping in pack.catmap.get("mappings", []):
-        allowed: Set[str] = set()
-        for key in ("props_required", "props_recommended"):
-            allowed.update(mapping.get(key, []))
-        allowed.update(collect_from_groups(mapping.get("groups_required", [])))
-        allowed.update(collect_from_groups(mapping.get("groups_recommended", [])))
-        for target in mapping.get("keynote_mapping", {}).values():
-            if isinstance(target, str) and target:
-                allowed.add(target)
-
-        cat_label = str(mapping.get("cat_label", "")).lower()
-        cat_id = str(mapping.get("cat_id", "")).lower()
-        frozen = set(allowed)
-        if cat_label:
-            index[cat_label] = frozen
-        if cat_id:
-            index[cat_id] = frozen
-
-    setattr(pack, "_category_property_index", index)
-    return index
-
-
-def predict_properties(text: str, pack, categories: Any) -> Dict[str, Any]:
-    """
-    Extract properties from ``text`` limited to those allowed for ``categories``.
-
-    ``categories`` can be expressed as a string, dict, iterable or nested
-    combination of the previous forms. Only the properties whose identifiers are
-    both declared in the extractors pack and allowed by the category mappings
-    are returned.
-    """
-
-    labels = {label.strip() for label in _normalize_category_labels(categories) if label}
-    allowed_properties: Optional[Set[str]] = None
-    if labels:
-        index = _category_property_index(pack)
-        extractor_ids = _extractor_property_ids(pack)
-        collected: Set[str] = set()
-        for label in labels:
-            key = label.lower()
-            collected.update(index.get(key, set()))
-        collected.intersection_update(extractor_ids)
-        if collected:
-            allowed_properties = collected
-
-    return extract_properties(text, pack.extractors, allowed_properties=allowed_properties)
-
-
-__all__ = [
-    "predict_properties",
-    "_normalize_category_labels",
-    "_extractor_property_ids",
-    "_category_property_index",
-]

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,0 +1,38 @@
+import json
+
+import pytest
+
+from robimb.extraction.llm_adapter import SchemaField, StructuredLLMAdapter
+
+
+def test_structured_llm_adapter_builds_prompt():
+    adapter = StructuredLLMAdapter({"roof.color": SchemaField(type="string", description="Colore principale")})
+    prompt = adapter.build_prompt("roof color red")
+    assert "roof.color" in prompt
+    assert "Colore principale" in prompt
+
+
+def test_structured_llm_adapter_parses_response():
+    schema = {
+        "roof.color": SchemaField(type="string"),
+        "roof.score": SchemaField(type="number"),
+    }
+    adapter = StructuredLLMAdapter(schema)
+    response = json.dumps(
+        {
+            "roof.color": {"value": "red", "confidence": 0.75},
+            "roof.score": 0.5,
+        }
+    )
+    stage = adapter.build_stage(response)
+    assert len(stage.candidates) == 2
+    color_candidate = [c for c in stage.candidates if c.property_id == "roof.color"][0]
+    assert color_candidate.value == "red"
+    assert color_candidate.confidence == pytest.approx(0.75)
+
+
+def test_structured_llm_adapter_rejects_invalid_json():
+    adapter = StructuredLLMAdapter({"roof.color": "string"})
+    with pytest.raises(ValueError):
+        adapter.parse_response("not-json")
+

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -1,4 +1,7 @@
-from robimb.extraction.normalizers import BUILTIN_NORMALIZERS
+import pytest
+
+from robimb.extraction import BUILTIN_NORMALIZERS, apply_postprocess
+from robimb.registry.schemas import CategoryDefinition, PropertySlot
 
 
 _truncate = BUILTIN_NORMALIZERS["truncate_model_value"]
@@ -32,3 +35,24 @@ def test_truncate_model_value_keeps_short_codes():
     value = "PX"
     context = "modello PX"
     assert _truncate(value, context) == "PX"
+
+
+def test_apply_postprocess_coerces_values():
+    category = CategoryDefinition(
+        key="demo|demo",
+        super="Demo",
+        category="Demo",
+        slots={
+            "demo.number": PropertySlot(property_id="demo.number", name="Number", type="float"),
+            "demo.flag": PropertySlot(property_id="demo.flag", name="Flag", type="bool"),
+        },
+    )
+    result = apply_postprocess(
+        {"demo.number": "1,5", "demo.flag": "SI"},
+        category=category,
+        validators=None,
+        category_label="Demo",
+    )
+    assert result.values["demo.number"] == pytest.approx(1.5)
+    assert result.values["demo.flag"] is True
+

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from robimb.extraction import ExtractionRouter, SpanTagger
+from robimb.registry.schemas import CategoryDefinition, PropertySlot
+
+
+def _make_pack(span_enabled: bool = False) -> SimpleNamespace:
+    category = CategoryDefinition(
+        key="roof|roof",
+        super="Roof",
+        category="Roof",
+        slots={
+            "roof.color": PropertySlot(property_id="roof.color", name="Color", type="text"),
+            "roof.extra": PropertySlot(property_id="roof.extra", name="Extra", type="bool"),
+        },
+    )
+    extractors = {
+        "patterns": [
+            {"property_id": "roof.color", "regex": [r"roof color (\w+)"], "confidence": 0.8},
+        ]
+    }
+    catmap = {
+        "mappings": [
+            {
+                "cat_label": "Roof",
+                "props_required": ["roof.color"],
+                "props_recommended": ["roof.extra"],
+                "groups_required": [],
+                "groups_recommended": [],
+                "keynote_mapping": {},
+            }
+        ]
+    }
+    validators = {"rules": []}
+    registry = {"groups": {}}
+    pack = SimpleNamespace(
+        extractors=extractors,
+        catmap=catmap,
+        validators=validators,
+        registry=registry,
+        category_models={category.key: category},
+    )
+    if span_enabled:
+        pack.span_router = True  # sentinel for tests
+    return pack
+
+
+def test_router_runs_rule_stage_and_postprocess():
+    pack = _make_pack()
+    router = ExtractionRouter(pack)
+    result = router.extract("roof color red", categories="Roof")
+
+    assert result.values() == {"roof.color": "red"}
+    assert result.extraction.stages[0].stage == "R0"
+    assert result.extraction.stages[0].candidates[0].provenance == "rules:regex"
+
+
+def test_router_merges_span_tagger_predictions():
+    pack = _make_pack(span_enabled=True)
+
+    def _predictor(text, allowed):
+        yield {"property_id": "roof.extra", "value": "true", "confidence": 0.6}
+        yield {"property_id": "ignored.prop", "value": 1}
+
+    router = ExtractionRouter(pack, span_tagger=SpanTagger(_predictor))
+    result = router.extract("roof color blue", categories="Roof")
+
+    assert result.values()["roof.color"] == "blue"
+    assert result.values()["roof.extra"] is True
+    best = result.extraction.best_by_property()["roof.extra"]
+    assert best.stage == "R1"
+    assert result.postprocess.issues == [] or result.postprocess.issues is None
+


### PR DESCRIPTION
## Summary
- add shared extraction data structures plus router, rules, span tagger, LLM adapter, and postprocessing modules to support multi-stage property extraction
- integrate the router into inference and service layers so CLI and API reuse normalization and validation
- add regression tests covering the router orchestration, structured LLM adapter, and registry-driven normalization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daa79a8f3c8322a08ce31e651a388c