### PR TITLE
Refine v1_limited pack using lim dataset coverage

### DIFF
--- a/docs/lim_dataset_coverage.md
+++ b/docs/lim_dataset_coverage.md
@@ -1,0 +1,421 @@
+# Dataset lim coverage snapshot
+
+- Records analysed: 3186
+- Super categories present: 7
+- Category pairs present: 49
+
+## Slots never populated
+
+- `apparecchi_sanitari_e_accessori.__global__.portata_l_min`
+- `apparecchi_sanitari_e_accessori.accessori_per_l_allestimento_di_servizi_igienici.portata_massima_kg`
+- `apparecchi_sanitari_e_accessori.accessori_per_l_allestimento_di_servizi_igienici.tipologia_accessorio`
+- `apparecchi_sanitari_e_accessori.cassette_di_scarico.capacita_serbatoio_l`
+- `controsoffitti.botole_d_ispezione_e_accessori.dimensione_botola_mm`
+- `controsoffitti.botole_d_ispezione_e_accessori.tipologia_apertura`
+- `controsoffitti.controsoffitti_a_baffles_e_ispezionabili.passo_baffles_mm`
+- `controsoffitti.controsoffitti_in_pvc_o_materiali_plastici.resistenza_umidita`
+- `opere_da_cartongessista.__global__.presenza_isolante`
+- `opere_da_falegname.__global__.essenza`
+- `opere_da_falegname.opere_in_legno_custom.descrizione_custom`
+- `opere_da_falegname.opere_in_legno_custom.destinazione_uso`
+- `opere_da_falegname.persiane_e_scuri_in_legno.numero_ante`
+- `opere_da_falegname.persiane_e_scuri_in_legno.tipologia_lamelle`
+- `opere_da_serramentista.avvolgibili_controtelai_cassonetti_e_persiane.motorizzazione`
+- `opere_da_serramentista.avvolgibili_controtelai_cassonetti_e_persiane.tipologia_avvolgibile`
+- `opere_da_serramentista.porte_blindate_portoni_e_bussole.classe_antieffrazione`
+- `opere_da_serramentista.serramenti_in_legno.essenza`
+- `opere_da_serramentista.serramenti_in_legno_e_alluminio.materiale_rivestimento_esterno`
+- `opere_da_serramentista.sistemi_di_partizione_trasparenti_porte_e_parapetti_vetrati.classe_sicurezza_vetro`
+- `opere_di_pavimentazione.__global__.classe_resistenza_usura`
+- `opere_di_pavimentazione.__global__.classe_scivolosita`
+- `opere_di_pavimentazione.pavimentazione_in_autobloccanti_o_masselli.classe_resistenza_carico`
+- `opere_di_pavimentazione.pavimenti_in_gomma_o_pvc.classe_emissione`
+- `opere_di_pavimentazione.pavimenti_in_legno_e_laminato.essenza`
+- `opere_di_rivestimento.__global__.posa`
+- `opere_di_rivestimento.rivestimenti_in_gomma_o_pvc.classe_antisdrucciolo`
+- `opere_di_rivestimento.rivestimenti_in_legno.essenza`
+
+## Top populated slots by category
+
+### Apparecchi sanitari e accessori → Accessori per l'allestimento di servizi igienici
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `apparecchi_sanitari_e_accessori.__global__.marchio` | 100.0% | 58/58 |
+| `apparecchi_sanitari_e_accessori.__global__.materiale` | 79.3% | 46/58 |
+| `apparecchi_sanitari_e_accessori.accessori_per_l_allestimento_di_servizi_igienici.modalita_fissaggio` | 17.2% | 10/58 |
+
+### Apparecchi sanitari e accessori → Apparecchi sanitari
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `apparecchi_sanitari_e_accessori.__global__.marchio` | 100.0% | 157/157 |
+| `apparecchi_sanitari_e_accessori.__global__.materiale` | 87.9% | 138/157 |
+| `apparecchi_sanitari_e_accessori.apparecchi_sanitari.tipologia_apparecchio` | 79.0% | 124/157 |
+
+### Apparecchi sanitari e accessori → Cassette di scarico
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `apparecchi_sanitari_e_accessori.cassette_di_scarico.tipologia_cassetta` | 100.0% | 4/4 |
+| `apparecchi_sanitari_e_accessori.__global__.materiale` | 100.0% | 4/4 |
+| `apparecchi_sanitari_e_accessori.__global__.marchio` | 100.0% | 4/4 |
+
+### Controsoffitti → Botole d'ispezione e accessori
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `controsoffitti.__global__.materiale` | 100.0% | 48/48 |
+| `controsoffitti.__global__.marchio` | 79.2% | 38/48 |
+| `controsoffitti.__global__.stratigrafia_lastre` | 60.4% | 29/48 |
+
+### Controsoffitti → Controsoffitti a Baffles e ispezionabili
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `controsoffitti.__global__.materiale` | 100.0% | 18/18 |
+| `controsoffitti.__global__.marchio` | 88.9% | 16/18 |
+| `controsoffitti.__global__.classe_reazione_al_fuoco` | 5.6% | 1/18 |
+
+### Controsoffitti → Controsoffitti a doghe in legno
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `controsoffitti.__global__.materiale` | 100.0% | 1/1 |
+| `controsoffitti.__global__.marchio` | 100.0% | 1/1 |
+
+### Controsoffitti → Controsoffitti in PVC o materiali plastici
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `controsoffitti.__global__.materiale` | 100.0% | 4/4 |
+| `controsoffitti.__global__.marchio` | 50.0% | 2/4 |
+
+### Controsoffitti → Controsoffitti in altri materiali
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `controsoffitti.__global__.spessore_pannello_mm` | 100.0% | 7/7 |
+| `controsoffitti.__global__.materiale` | 100.0% | 7/7 |
+| `controsoffitti.__global__.marchio` | 100.0% | 7/7 |
+
+### Controsoffitti → Controsoffitti in cartongesso
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `controsoffitti.__global__.materiale` | 100.0% | 98/98 |
+| `controsoffitti.__global__.stratigrafia_lastre` | 87.8% | 86/98 |
+| `controsoffitti.__global__.marchio` | 85.7% | 84/98 |
+
+### Controsoffitti → Controsoffitti in fibre minerali e acustici
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `controsoffitti.__global__.materiale` | 100.0% | 47/47 |
+| `controsoffitti.__global__.stratigrafia_lastre` | 74.5% | 35/47 |
+| `controsoffitti.__global__.marchio` | 72.3% | 34/47 |
+
+### Controsoffitti → Controsoffitti metallici
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `controsoffitti.__global__.materiale` | 96.4% | 81/84 |
+| `controsoffitti.__global__.marchio` | 52.4% | 44/84 |
+| `controsoffitti.__global__.spessore_pannello_mm` | 26.2% | 22/84 |
+
+### Controsoffitti → Velette di raccordo
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `controsoffitti.__global__.materiale` | 100.0% | 44/44 |
+| `controsoffitti.__global__.marchio` | 97.7% | 43/44 |
+| `controsoffitti.__global__.stratigrafia_lastre` | 88.6% | 39/44 |
+
+### Opere da cartongessista → Accessori per cartongessi
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_cartongessista.accessori_per_cartongessi.tipologia_accessorio` | 94.6% | 105/111 |
+| `opere_da_cartongessista.__global__.spessore_mm` | 89.2% | 99/111 |
+| `opere_da_cartongessista.__global__.stratigrafia_lastre` | 80.2% | 89/111 |
+
+### Opere da cartongessista → Contropareti in cartongesso resistente al fuoco
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_cartongessista.__global__.stratigrafia_lastre` | 100.0% | 34/34 |
+| `opere_da_cartongessista.__global__.spessore_mm` | 97.1% | 33/34 |
+| `opere_da_cartongessista.__global__.marchio` | 97.1% | 33/34 |
+
+### Opere da cartongessista → Contropareti in cartongesso standard e idrorepellente
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_cartongessista.__global__.stratigrafia_lastre` | 99.1% | 108/109 |
+| `opere_da_cartongessista.__global__.spessore_mm` | 99.1% | 108/109 |
+| `opere_da_cartongessista.__global__.tipologia_lastra` | 95.4% | 104/109 |
+
+### Opere da cartongessista → Contropareti in lastre di fibrocemento
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_cartongessista.__global__.stratigrafia_lastre` | 100.0% | 8/8 |
+| `opere_da_cartongessista.__global__.spessore_mm` | 100.0% | 8/8 |
+| `opere_da_cartongessista.__global__.marchio` | 100.0% | 8/8 |
+
+### Opere da cartongessista → Pareti in cartongesso resistente al fuoco
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_cartongessista.__global__.stratigrafia_lastre` | 100.0% | 53/53 |
+| `opere_da_cartongessista.__global__.marchio` | 100.0% | 53/53 |
+| `opere_da_cartongessista.__global__.tipologia_lastra` | 90.6% | 48/53 |
+
+### Opere da cartongessista → Pareti in cartongesso standard e idrorepellente
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_cartongessista.__global__.spessore_mm` | 98.8% | 162/164 |
+| `opere_da_cartongessista.__global__.tipologia_lastra` | 97.6% | 160/164 |
+| `opere_da_cartongessista.__global__.stratigrafia_lastre` | 97.6% | 160/164 |
+
+### Opere da cartongessista → Pareti in lastre di fibrocemento
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_cartongessista.__global__.stratigrafia_lastre` | 100.0% | 6/6 |
+| `opere_da_cartongessista.__global__.spessore_mm` | 100.0% | 6/6 |
+| `opere_da_cartongessista.__global__.marchio` | 100.0% | 6/6 |
+
+### Opere da cartongessista → Setto autoportante cartongesso resistente al fuoco
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_cartongessista.__global__.tipologia_lastra` | 100.0% | 54/54 |
+| `opere_da_cartongessista.__global__.stratigrafia_lastre` | 100.0% | 54/54 |
+| `opere_da_cartongessista.__global__.marchio` | 100.0% | 54/54 |
+
+### Opere da cartongessista → Setto autoportante in cartongesso standard e idrorepellente
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_cartongessista.__global__.tipologia_lastra` | 100.0% | 17/17 |
+| `opere_da_cartongessista.__global__.spessore_mm` | 100.0% | 17/17 |
+| `opere_da_cartongessista.__global__.marchio` | 100.0% | 17/17 |
+
+### Opere da falegname → Boiserie in legno
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_falegname.__global__.marchio` | 40.0% | 8/20 |
+| `opere_da_falegname.__global__.dimensione_larghezza` | 20.0% | 4/20 |
+
+### Opere da falegname → Opere in legno custom
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_falegname.__global__.marchio` | 100.0% | 6/6 |
+| `opere_da_falegname.__global__.dimensione_altezza` | 66.7% | 4/6 |
+
+### Opere da falegname → Persiane e scuri in legno
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_falegname.__global__.marchio` | 77.8% | 14/18 |
+| `opere_da_falegname.__global__.dimensione_altezza` | 27.8% | 5/18 |
+
+### Opere da falegname → Porte in legno
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_falegname.__global__.marchio` | 96.9% | 126/130 |
+| `opere_da_falegname.porte_in_legno.tipologia_porta` | 76.9% | 100/130 |
+| `opere_da_falegname.__global__.dimensione_altezza` | 67.7% | 88/130 |
+
+### Opere da serramentista → Avvolgibili, controtelai, cassonetti e persiane
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_serramentista.__global__.materiale_struttura` | 100.0% | 66/66 |
+
+### Opere da serramentista → Porte blindate, portoni e bussole
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_serramentista.__global__.materiale_struttura` | 94.9% | 37/39 |
+| `opere_da_serramentista.__global__.marchio` | 15.4% | 6/39 |
+
+### Opere da serramentista → Porte metalliche
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_serramentista.__global__.materiale_struttura` | 100.0% | 24/24 |
+| `opere_da_serramentista.__global__.marchio` | 100.0% | 24/24 |
+| `opere_da_serramentista.__global__.dimensione_altezza` | 100.0% | 24/24 |
+
+### Opere da serramentista → Porte tagliafuoco
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_serramentista.__global__.materiale_struttura` | 100.0% | 148/148 |
+| `opere_da_serramentista.__global__.marchio` | 95.9% | 142/148 |
+| `opere_da_serramentista.__global__.dimensione_altezza` | 70.3% | 104/148 |
+
+### Opere da serramentista → Serramenti in PVC
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_serramentista.__global__.materiale_struttura` | 100.0% | 96/96 |
+| `opere_da_serramentista.__global__.marchio` | 63.5% | 61/96 |
+| `opere_da_serramentista.serramenti_in_pvc.numero_camere` | 20.8% | 20/96 |
+
+### Opere da serramentista → Serramenti in legno
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_serramentista.__global__.materiale_struttura` | 100.0% | 97/97 |
+| `opere_da_serramentista.__global__.marchio` | 91.8% | 89/97 |
+
+### Opere da serramentista → Serramenti in legno e alluminio
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_serramentista.__global__.materiale_struttura` | 100.0% | 76/76 |
+| `opere_da_serramentista.__global__.marchio` | 84.2% | 64/76 |
+| `opere_da_serramentista.__global__.isolamento_acustico_db` | 53.9% | 41/76 |
+
+### Opere da serramentista → Serramenti metallici
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_serramentista.__global__.materiale_struttura` | 98.8% | 85/86 |
+| `opere_da_serramentista.__global__.marchio` | 73.3% | 63/86 |
+| `opere_da_serramentista.serramenti_metallici.lega_metallo` | 34.9% | 30/86 |
+
+### Opere da serramentista → Sistemi di partizione trasparenti, porte e parapetti vetrati
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_da_serramentista.__global__.materiale_struttura` | 100.0% | 90/90 |
+| `opere_da_serramentista.__global__.marchio` | 95.6% | 86/90 |
+| `opere_da_serramentista.__global__.dimensione_altezza` | 46.7% | 42/90 |
+
+### Opere di pavimentazione → Pavimentazione in autobloccanti o masselli
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 100.0% | 57/57 |
+| `opere_di_pavimentazione.__global__.marchio` | 80.7% | 46/57 |
+| `opere_di_pavimentazione.pavimentazione_in_autobloccanti_o_masselli.tipologia_blocco` | 38.6% | 22/57 |
+
+### Opere di pavimentazione → Pavimenti in altri materiali
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 96.2% | 50/52 |
+| `opere_di_pavimentazione.__global__.marchio` | 42.3% | 22/52 |
+| `opere_di_pavimentazione.__global__.spessore_mm` | 13.5% | 7/52 |
+
+### Opere di pavimentazione → Pavimenti in gomma o PVC
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 94.3% | 164/174 |
+| `opere_di_pavimentazione.__global__.spessore_mm` | 63.8% | 111/174 |
+| `opere_di_pavimentazione.__global__.marchio` | 40.8% | 71/174 |
+
+### Opere di pavimentazione → Pavimenti in gres e ceramica
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 100.0% | 108/108 |
+| `opere_di_pavimentazione.__global__.marchio` | 58.3% | 63/108 |
+| `opere_di_pavimentazione.__global__.spessore_mm` | 42.6% | 46/108 |
+
+### Opere di pavimentazione → Pavimenti in legno e laminato
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 100.0% | 109/109 |
+| `opere_di_pavimentazione.__global__.spessore_mm` | 25.7% | 28/109 |
+| `opere_di_pavimentazione.__global__.marchio` | 23.9% | 26/109 |
+
+### Opere di pavimentazione → Pavimenti in moquette e zerbini
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 100.0% | 34/34 |
+| `opere_di_pavimentazione.__global__.marchio` | 70.6% | 24/34 |
+| `opere_di_pavimentazione.pavimenti_in_moquette_e_zerbini.tipologia_fibra` | 29.4% | 10/34 |
+
+### Opere di pavimentazione → Pavimenti in pietra
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 100.0% | 98/98 |
+| `opere_di_pavimentazione.__global__.spessore_mm` | 63.3% | 62/98 |
+| `opere_di_pavimentazione.pavimenti_in_pietra.tipo_pietra` | 46.9% | 46/98 |
+
+### Opere di pavimentazione → Pavimenti industriali
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 100.0% | 43/43 |
+| `opere_di_pavimentazione.__global__.marchio` | 39.5% | 17/43 |
+| `opere_di_pavimentazione.__global__.spessore_mm` | 20.9% | 9/43 |
+
+### Opere di pavimentazione → Pavimenti sopraelevati e flottanti
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 100.0% | 65/65 |
+| `opere_di_pavimentazione.__global__.marchio` | 70.8% | 46/65 |
+| `opere_di_pavimentazione.__global__.spessore_mm` | 46.2% | 30/65 |
+
+### Opere di pavimentazione → Zoccolini e accessori per pavimentazioni
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_pavimentazione.__global__.materiale` | 99.3% | 143/144 |
+| `opere_di_pavimentazione.__global__.marchio` | 54.9% | 79/144 |
+| `opere_di_pavimentazione.__global__.spessore_mm` | 29.2% | 42/144 |
+
+### Opere di rivestimento → Altri rivestimenti
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_rivestimento.__global__.materiale` | 85.5% | 47/55 |
+| `opere_di_rivestimento.__global__.marchio` | 85.5% | 47/55 |
+| `opere_di_rivestimento.__global__.finitura` | 54.5% | 30/55 |
+
+### Opere di rivestimento → Rivestimenti in gomma o PVC
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_rivestimento.__global__.materiale` | 100.0% | 49/49 |
+| `opere_di_rivestimento.__global__.spessore_mm` | 67.3% | 33/49 |
+
+### Opere di rivestimento → Rivestimenti in gres e ceramica
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_rivestimento.__global__.materiale` | 81.8% | 54/66 |
+| `opere_di_rivestimento.__global__.marchio` | 47.0% | 31/66 |
+| `opere_di_rivestimento.__global__.spessore_mm` | 42.4% | 28/66 |
+
+### Opere di rivestimento → Rivestimenti in legno
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_rivestimento.__global__.spessore_mm` | 100.0% | 45/45 |
+| `opere_di_rivestimento.__global__.materiale` | 100.0% | 45/45 |
+| `opere_di_rivestimento.__global__.marchio` | 100.0% | 45/45 |
+
+### Opere di rivestimento → Rivestimenti in pietra
+
+| Slot | Copertura | Valori presenti / totali |
+| --- | --- | --- |
+| `opere_di_rivestimento.__global__.materiale` | 100.0% | 65/65 |
+| `opere_di_rivestimento.__global__.spessore_mm` | 35.4% | 23/65 |
+| `opere_di_rivestimento.__global__.marchio` | 6.2% | 4/65 |
+

--- a/pack/v1_limited/templates.json
+++ b/pack/v1_limited/templates.json
@@ -8,14 +8,10 @@
       "fields": [
         "apparecchi_sanitari_e_accessori.__global__.marchio",
         "apparecchi_sanitari_e_accessori.__global__.materiale",
-        "apparecchi_sanitari_e_accessori.__global__.dimensione_lunghezza",
-        "apparecchi_sanitari_e_accessori.__global__.dimensione_larghezza",
-        "apparecchi_sanitari_e_accessori.__global__.dimensione_altezza",
-        "apparecchi_sanitari_e_accessori.__global__.tipologia_installazione",
-        "apparecchi_sanitari_e_accessori.__global__.portata_l_min",
-        "apparecchi_sanitari_e_accessori.accessori_per_l_allestimento_di_servizi_igienici.tipologia_accessorio",
         "apparecchi_sanitari_e_accessori.accessori_per_l_allestimento_di_servizi_igienici.modalita_fissaggio",
-        "apparecchi_sanitari_e_accessori.accessori_per_l_allestimento_di_servizi_igienici.portata_massima_kg"
+        "apparecchi_sanitari_e_accessori.__global__.dimensione_lunghezza",
+        "apparecchi_sanitari_e_accessori.__global__.dimensione_altezza",
+        "apparecchi_sanitari_e_accessori.__global__.dimensione_larghezza"
       ]
     },
     {
@@ -25,13 +21,10 @@
       "fields": [
         "apparecchi_sanitari_e_accessori.__global__.marchio",
         "apparecchi_sanitari_e_accessori.__global__.materiale",
-        "apparecchi_sanitari_e_accessori.__global__.dimensione_lunghezza",
-        "apparecchi_sanitari_e_accessori.__global__.dimensione_larghezza",
-        "apparecchi_sanitari_e_accessori.__global__.dimensione_altezza",
-        "apparecchi_sanitari_e_accessori.__global__.tipologia_installazione",
-        "apparecchi_sanitari_e_accessori.__global__.portata_l_min",
         "apparecchi_sanitari_e_accessori.apparecchi_sanitari.tipologia_apparecchio",
-        "apparecchi_sanitari_e_accessori.apparecchi_sanitari.scarico"
+        "apparecchi_sanitari_e_accessori.__global__.tipologia_installazione",
+        "apparecchi_sanitari_e_accessori.apparecchi_sanitari.scarico",
+        "apparecchi_sanitari_e_accessori.__global__.dimensione_altezza"
       ]
     },
     {
@@ -41,13 +34,7 @@
       "fields": [
         "apparecchi_sanitari_e_accessori.__global__.marchio",
         "apparecchi_sanitari_e_accessori.__global__.materiale",
-        "apparecchi_sanitari_e_accessori.__global__.dimensione_lunghezza",
-        "apparecchi_sanitari_e_accessori.__global__.dimensione_larghezza",
-        "apparecchi_sanitari_e_accessori.__global__.dimensione_altezza",
-        "apparecchi_sanitari_e_accessori.__global__.tipologia_installazione",
-        "apparecchi_sanitari_e_accessori.__global__.portata_l_min",
-        "apparecchi_sanitari_e_accessori.cassette_di_scarico.tipologia_cassetta",
-        "apparecchi_sanitari_e_accessori.cassette_di_scarico.capacita_serbatoio_l"
+        "apparecchi_sanitari_e_accessori.cassette_di_scarico.tipologia_cassetta"
       ]
     },
     {
@@ -55,8 +42,10 @@
       "label": "Scheda Accessori per cartongessi",
       "category": "Opere da cartongessista|Accessori per cartongessi",
       "fields": [
-        "opere_da_cartongessista.__global__.marchio",
-        "opere_da_cartongessista.accessori_per_cartongessi.tipologia_accessorio"
+        "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.accessori_per_cartongessi.tipologia_accessorio",
+        "opere_da_cartongessista.__global__.marchio"
       ]
     },
     {
@@ -64,13 +53,12 @@
       "label": "Scheda Contropareti in cartongesso resistente al fuoco",
       "category": "Opere da cartongessista|Contropareti in cartongesso resistente al fuoco",
       "fields": [
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
         "opere_da_cartongessista.__global__.marchio",
-        "opere_da_cartongessista.__global__.tipologia_lastra",
         "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.tipologia_lastra",
         "opere_da_cartongessista.__global__.classe_ei",
-        "opere_da_cartongessista.__global__.classe_reazione_al_fuoco",
-        "opere_da_cartongessista.__global__.presenza_isolante",
-        "opere_da_cartongessista.__global__.stratigrafia_lastre"
+        "opere_da_cartongessista.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -78,13 +66,12 @@
       "label": "Scheda Contropareti in cartongesso standard e idrorepellente",
       "category": "Opere da cartongessista|Contropareti in cartongesso standard e idrorepellente",
       "fields": [
-        "opere_da_cartongessista.__global__.marchio",
-        "opere_da_cartongessista.__global__.tipologia_lastra",
         "opere_da_cartongessista.__global__.spessore_mm",
-        "opere_da_cartongessista.__global__.classe_ei",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.__global__.tipologia_lastra",
+        "opere_da_cartongessista.__global__.marchio",
         "opere_da_cartongessista.__global__.classe_reazione_al_fuoco",
-        "opere_da_cartongessista.__global__.presenza_isolante",
-        "opere_da_cartongessista.__global__.stratigrafia_lastre"
+        "opere_da_cartongessista.__global__.classe_ei"
       ]
     },
     {
@@ -93,12 +80,10 @@
       "category": "Opere da cartongessista|Contropareti in lastre di fibrocemento",
       "fields": [
         "opere_da_cartongessista.__global__.marchio",
-        "opere_da_cartongessista.__global__.tipologia_lastra",
         "opere_da_cartongessista.__global__.spessore_mm",
-        "opere_da_cartongessista.__global__.classe_ei",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
         "opere_da_cartongessista.__global__.classe_reazione_al_fuoco",
-        "opere_da_cartongessista.__global__.presenza_isolante",
-        "opere_da_cartongessista.__global__.stratigrafia_lastre"
+        "opere_da_cartongessista.__global__.tipologia_lastra"
       ]
     },
     {
@@ -107,12 +92,11 @@
       "category": "Opere da cartongessista|Pareti in cartongesso resistente al fuoco",
       "fields": [
         "opere_da_cartongessista.__global__.marchio",
-        "opere_da_cartongessista.__global__.tipologia_lastra",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
         "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.tipologia_lastra",
         "opere_da_cartongessista.__global__.classe_ei",
-        "opere_da_cartongessista.__global__.classe_reazione_al_fuoco",
-        "opere_da_cartongessista.__global__.presenza_isolante",
-        "opere_da_cartongessista.__global__.stratigrafia_lastre"
+        "opere_da_cartongessista.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -120,13 +104,12 @@
       "label": "Scheda Pareti in cartongesso standard e idrorepellente",
       "category": "Opere da cartongessista|Pareti in cartongesso standard e idrorepellente",
       "fields": [
-        "opere_da_cartongessista.__global__.marchio",
-        "opere_da_cartongessista.__global__.tipologia_lastra",
         "opere_da_cartongessista.__global__.spessore_mm",
-        "opere_da_cartongessista.__global__.classe_ei",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.__global__.tipologia_lastra",
+        "opere_da_cartongessista.__global__.marchio",
         "opere_da_cartongessista.__global__.classe_reazione_al_fuoco",
-        "opere_da_cartongessista.__global__.presenza_isolante",
-        "opere_da_cartongessista.__global__.stratigrafia_lastre"
+        "opere_da_cartongessista.__global__.classe_ei"
       ]
     },
     {
@@ -135,12 +118,9 @@
       "category": "Opere da cartongessista|Pareti in lastre di fibrocemento",
       "fields": [
         "opere_da_cartongessista.__global__.marchio",
-        "opere_da_cartongessista.__global__.tipologia_lastra",
         "opere_da_cartongessista.__global__.spessore_mm",
-        "opere_da_cartongessista.__global__.classe_ei",
-        "opere_da_cartongessista.__global__.classe_reazione_al_fuoco",
-        "opere_da_cartongessista.__global__.presenza_isolante",
-        "opere_da_cartongessista.__global__.stratigrafia_lastre"
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.__global__.tipologia_lastra"
       ]
     },
     {
@@ -149,12 +129,10 @@
       "category": "Opere da cartongessista|Setto autoportante cartongesso resistente al fuoco",
       "fields": [
         "opere_da_cartongessista.__global__.marchio",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
         "opere_da_cartongessista.__global__.tipologia_lastra",
         "opere_da_cartongessista.__global__.spessore_mm",
-        "opere_da_cartongessista.__global__.classe_ei",
-        "opere_da_cartongessista.__global__.classe_reazione_al_fuoco",
-        "opere_da_cartongessista.__global__.presenza_isolante",
-        "opere_da_cartongessista.__global__.stratigrafia_lastre"
+        "opere_da_cartongessista.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -163,12 +141,11 @@
       "category": "Opere da cartongessista|Setto autoportante in cartongesso standard e idrorepellente",
       "fields": [
         "opere_da_cartongessista.__global__.marchio",
-        "opere_da_cartongessista.__global__.tipologia_lastra",
         "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.tipologia_lastra",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
         "opere_da_cartongessista.__global__.classe_ei",
-        "opere_da_cartongessista.__global__.classe_reazione_al_fuoco",
-        "opere_da_cartongessista.__global__.presenza_isolante",
-        "opere_da_cartongessista.__global__.stratigrafia_lastre"
+        "opere_da_cartongessista.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -176,13 +153,10 @@
       "label": "Scheda Botole d'ispezione e accessori",
       "category": "Controsoffitti|Botole d'ispezione e accessori",
       "fields": [
-        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.spessore_pannello_mm",
-        "controsoffitti.__global__.classe_reazione_al_fuoco",
-        "controsoffitti.__global__.coefficiente_fonoassorbimento",
-        "controsoffitti.botole_d_ispezione_e_accessori.dimensione_botola_mm",
-        "controsoffitti.botole_d_ispezione_e_accessori.tipologia_apertura"
+        "controsoffitti.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -190,12 +164,9 @@
       "label": "Scheda Controsoffitti a Baffles e ispezionabili",
       "category": "Controsoffitti|Controsoffitti a Baffles e ispezionabili",
       "fields": [
-        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.materiale",
-        "controsoffitti.__global__.spessore_pannello_mm",
-        "controsoffitti.__global__.classe_reazione_al_fuoco",
-        "controsoffitti.__global__.coefficiente_fonoassorbimento",
-        "controsoffitti.controsoffitti_a_baffles_e_ispezionabili.passo_baffles_mm"
+        "controsoffitti.__global__.marchio",
+        "controsoffitti.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -204,10 +175,7 @@
       "category": "Controsoffitti|Controsoffitti a doghe in legno",
       "fields": [
         "controsoffitti.__global__.marchio",
-        "controsoffitti.__global__.materiale",
-        "controsoffitti.__global__.spessore_pannello_mm",
-        "controsoffitti.__global__.classe_reazione_al_fuoco",
-        "controsoffitti.__global__.coefficiente_fonoassorbimento"
+        "controsoffitti.__global__.materiale"
       ]
     },
     {
@@ -215,12 +183,8 @@
       "label": "Scheda Controsoffitti in PVC o materiali plastici",
       "category": "Controsoffitti|Controsoffitti in PVC o materiali plastici",
       "fields": [
-        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.materiale",
-        "controsoffitti.__global__.spessore_pannello_mm",
-        "controsoffitti.__global__.classe_reazione_al_fuoco",
-        "controsoffitti.__global__.coefficiente_fonoassorbimento",
-        "controsoffitti.controsoffitti_in_pvc_o_materiali_plastici.resistenza_umidita"
+        "controsoffitti.__global__.marchio"
       ]
     },
     {
@@ -231,8 +195,7 @@
         "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.materiale",
         "controsoffitti.__global__.spessore_pannello_mm",
-        "controsoffitti.__global__.classe_reazione_al_fuoco",
-        "controsoffitti.__global__.coefficiente_fonoassorbimento"
+        "controsoffitti.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -240,12 +203,11 @@
       "label": "Scheda Controsoffitti in cartongesso",
       "category": "Controsoffitti|Controsoffitti in cartongesso",
       "fields": [
-        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.stratigrafia_lastre",
+        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.spessore_pannello_mm",
-        "controsoffitti.__global__.classe_reazione_al_fuoco",
-        "controsoffitti.__global__.coefficiente_fonoassorbimento",
-        "controsoffitti.__global__.stratigrafia_lastre"
+        "controsoffitti.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -253,8 +215,8 @@
       "label": "Scheda Controsoffitti in fibre minerali e acustici",
       "category": "Controsoffitti|Controsoffitti in fibre minerali e acustici",
       "fields": [
-        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.spessore_pannello_mm",
         "controsoffitti.__global__.classe_reazione_al_fuoco",
         "controsoffitti.__global__.coefficiente_fonoassorbimento"
@@ -265,11 +227,10 @@
       "label": "Scheda Controsoffitti metallici",
       "category": "Controsoffitti|Controsoffitti metallici",
       "fields": [
-        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.spessore_pannello_mm",
-        "controsoffitti.__global__.classe_reazione_al_fuoco",
-        "controsoffitti.__global__.coefficiente_fonoassorbimento"
+        "controsoffitti.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -277,12 +238,11 @@
       "label": "Scheda Velette di raccordo",
       "category": "Controsoffitti|Velette di raccordo",
       "fields": [
-        "controsoffitti.__global__.marchio",
         "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.marchio",
+        "controsoffitti.__global__.stratigrafia_lastre",
         "controsoffitti.__global__.spessore_pannello_mm",
-        "controsoffitti.__global__.classe_reazione_al_fuoco",
-        "controsoffitti.__global__.coefficiente_fonoassorbimento",
-        "controsoffitti.__global__.stratigrafia_lastre"
+        "controsoffitti.__global__.classe_reazione_al_fuoco"
       ]
     },
     {
@@ -290,14 +250,10 @@
       "label": "Scheda Pavimentazione in autobloccanti o masselli",
       "category": "Opere di pavimentazione|Pavimentazione in autobloccanti o masselli",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
-        "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita",
+        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.pavimentazione_in_autobloccanti_o_masselli.tipologia_blocco",
-        "opere_di_pavimentazione.pavimentazione_in_autobloccanti_o_masselli.classe_resistenza_carico"
+        "opere_di_pavimentazione.__global__.spessore_mm"
       ]
     },
     {
@@ -305,12 +261,9 @@
       "label": "Scheda Pavimenti in altri materiali",
       "category": "Opere di pavimentazione|Pavimenti in altri materiali",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
-        "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita"
+        "opere_di_pavimentazione.__global__.marchio",
+        "opere_di_pavimentazione.__global__.spessore_mm"
       ]
     },
     {
@@ -318,13 +271,9 @@
       "label": "Scheda Pavimenti in gomma o PVC",
       "category": "Opere di pavimentazione|Pavimenti in gomma o PVC",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
         "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita",
-        "opere_di_pavimentazione.pavimenti_in_gomma_o_pvc.classe_emissione"
+        "opere_di_pavimentazione.__global__.marchio"
       ]
     },
     {
@@ -332,12 +281,10 @@
       "label": "Scheda Pavimenti in gres e ceramica",
       "category": "Opere di pavimentazione|Pavimenti in gres e ceramica",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
+        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita"
+        "opere_di_pavimentazione.__global__.formato"
       ]
     },
     {
@@ -345,13 +292,9 @@
       "label": "Scheda Pavimenti in legno e laminato",
       "category": "Opere di pavimentazione|Pavimenti in legno e laminato",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
         "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita",
-        "opere_di_pavimentazione.pavimenti_in_legno_e_laminato.essenza"
+        "opere_di_pavimentazione.__global__.marchio"
       ]
     },
     {
@@ -359,12 +302,9 @@
       "label": "Scheda Pavimenti in moquette e zerbini",
       "category": "Opere di pavimentazione|Pavimenti in moquette e zerbini",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
+        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita",
         "opere_di_pavimentazione.pavimenti_in_moquette_e_zerbini.tipologia_fibra"
       ]
     },
@@ -373,13 +313,11 @@
       "label": "Scheda Pavimenti in pietra",
       "category": "Opere di pavimentazione|Pavimenti in pietra",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
         "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita",
-        "opere_di_pavimentazione.pavimenti_in_pietra.tipo_pietra"
+        "opere_di_pavimentazione.pavimenti_in_pietra.tipo_pietra",
+        "opere_di_pavimentazione.__global__.marchio",
+        "opere_di_pavimentazione.__global__.formato"
       ]
     },
     {
@@ -387,12 +325,10 @@
       "label": "Scheda Pavimenti industriali",
       "category": "Opere di pavimentazione|Pavimenti industriali",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
+        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita"
+        "opere_di_pavimentazione.__global__.formato"
       ]
     },
     {
@@ -400,13 +336,11 @@
       "label": "Scheda Pavimenti sopraelevati e flottanti",
       "category": "Opere di pavimentazione|Pavimenti sopraelevati e flottanti",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
+        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita",
-        "opere_di_pavimentazione.pavimenti_sopraelevati_e_flottanti.tipologia_struttura"
+        "opere_di_pavimentazione.pavimenti_sopraelevati_e_flottanti.tipologia_struttura",
+        "opere_di_pavimentazione.__global__.formato"
       ]
     },
     {
@@ -414,12 +348,9 @@
       "label": "Scheda Zoccolini e accessori per pavimentazioni",
       "category": "Opere di pavimentazione|Zoccolini e accessori per pavimentazioni",
       "fields": [
-        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.materiale",
-        "opere_di_pavimentazione.__global__.formato",
+        "opere_di_pavimentazione.__global__.marchio",
         "opere_di_pavimentazione.__global__.spessore_mm",
-        "opere_di_pavimentazione.__global__.classe_resistenza_usura",
-        "opere_di_pavimentazione.__global__.classe_scivolosita",
         "opere_di_pavimentazione.zoccolini_e_accessori_per_pavimentazioni.tipologia_zoccolino"
       ]
     },
@@ -432,7 +363,6 @@
         "opere_di_rivestimento.__global__.materiale",
         "opere_di_rivestimento.__global__.finitura",
         "opere_di_rivestimento.__global__.spessore_mm",
-        "opere_di_rivestimento.__global__.posa",
         "opere_di_rivestimento.__global__.classe_reazione_al_fuoco"
       ]
     },
@@ -441,13 +371,8 @@
       "label": "Scheda Rivestimenti in gomma o PVC",
       "category": "Opere di rivestimento|Rivestimenti in gomma o PVC",
       "fields": [
-        "opere_di_rivestimento.__global__.marchio",
         "opere_di_rivestimento.__global__.materiale",
-        "opere_di_rivestimento.__global__.finitura",
-        "opere_di_rivestimento.__global__.spessore_mm",
-        "opere_di_rivestimento.__global__.posa",
-        "opere_di_rivestimento.__global__.classe_reazione_al_fuoco",
-        "opere_di_rivestimento.rivestimenti_in_gomma_o_pvc.classe_antisdrucciolo"
+        "opere_di_rivestimento.__global__.spessore_mm"
       ]
     },
     {
@@ -455,12 +380,10 @@
       "label": "Scheda Rivestimenti in gres e ceramica",
       "category": "Opere di rivestimento|Rivestimenti in gres e ceramica",
       "fields": [
-        "opere_di_rivestimento.__global__.marchio",
         "opere_di_rivestimento.__global__.materiale",
-        "opere_di_rivestimento.__global__.finitura",
+        "opere_di_rivestimento.__global__.marchio",
         "opere_di_rivestimento.__global__.spessore_mm",
-        "opere_di_rivestimento.__global__.posa",
-        "opere_di_rivestimento.__global__.classe_reazione_al_fuoco"
+        "opere_di_rivestimento.__global__.finitura"
       ]
     },
     {
@@ -470,11 +393,7 @@
       "fields": [
         "opere_di_rivestimento.__global__.marchio",
         "opere_di_rivestimento.__global__.materiale",
-        "opere_di_rivestimento.__global__.finitura",
-        "opere_di_rivestimento.__global__.spessore_mm",
-        "opere_di_rivestimento.__global__.posa",
-        "opere_di_rivestimento.__global__.classe_reazione_al_fuoco",
-        "opere_di_rivestimento.rivestimenti_in_legno.essenza"
+        "opere_di_rivestimento.__global__.spessore_mm"
       ]
     },
     {
@@ -482,12 +401,9 @@
       "label": "Scheda Rivestimenti in pietra",
       "category": "Opere di rivestimento|Rivestimenti in pietra",
       "fields": [
-        "opere_di_rivestimento.__global__.marchio",
         "opere_di_rivestimento.__global__.materiale",
-        "opere_di_rivestimento.__global__.finitura",
         "opere_di_rivestimento.__global__.spessore_mm",
-        "opere_di_rivestimento.__global__.posa",
-        "opere_di_rivestimento.__global__.classe_reazione_al_fuoco",
+        "opere_di_rivestimento.__global__.marchio",
         "opere_di_rivestimento.rivestimenti_in_pietra.tipo_pietra"
       ]
     },
@@ -496,14 +412,7 @@
       "label": "Scheda Avvolgibili, controtelai, cassonetti e persiane",
       "category": "Opere da serramentista|Avvolgibili, controtelai, cassonetti e persiane",
       "fields": [
-        "opere_da_serramentista.__global__.marchio",
-        "opere_da_serramentista.__global__.materiale_struttura",
-        "opere_da_serramentista.__global__.dimensione_larghezza",
-        "opere_da_serramentista.__global__.dimensione_altezza",
-        "opere_da_serramentista.__global__.trasmittanza_termica",
-        "opere_da_serramentista.__global__.isolamento_acustico_db",
-        "opere_da_serramentista.avvolgibili_controtelai_cassonetti_e_persiane.tipologia_avvolgibile",
-        "opere_da_serramentista.avvolgibili_controtelai_cassonetti_e_persiane.motorizzazione"
+        "opere_da_serramentista.__global__.materiale_struttura"
       ]
     },
     {
@@ -511,13 +420,8 @@
       "label": "Scheda Porte blindate, portoni e bussole",
       "category": "Opere da serramentista|Porte blindate, portoni e bussole",
       "fields": [
-        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.materiale_struttura",
-        "opere_da_serramentista.__global__.dimensione_larghezza",
-        "opere_da_serramentista.__global__.dimensione_altezza",
-        "opere_da_serramentista.__global__.trasmittanza_termica",
-        "opere_da_serramentista.__global__.isolamento_acustico_db",
-        "opere_da_serramentista.porte_blindate_portoni_e_bussole.classe_antieffrazione"
+        "opere_da_serramentista.__global__.marchio"
       ]
     },
     {
@@ -525,12 +429,9 @@
       "label": "Scheda Porte metalliche",
       "category": "Opere da serramentista|Porte metalliche",
       "fields": [
-        "opere_da_serramentista.__global__.marchio",
-        "opere_da_serramentista.__global__.materiale_struttura",
-        "opere_da_serramentista.__global__.dimensione_larghezza",
         "opere_da_serramentista.__global__.dimensione_altezza",
-        "opere_da_serramentista.__global__.trasmittanza_termica",
-        "opere_da_serramentista.__global__.isolamento_acustico_db"
+        "opere_da_serramentista.__global__.marchio",
+        "opere_da_serramentista.__global__.materiale_struttura"
       ]
     },
     {
@@ -538,13 +439,13 @@
       "label": "Scheda Porte tagliafuoco",
       "category": "Opere da serramentista|Porte tagliafuoco",
       "fields": [
-        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.materiale_struttura",
-        "opere_da_serramentista.__global__.dimensione_larghezza",
+        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.dimensione_altezza",
         "opere_da_serramentista.__global__.trasmittanza_termica",
+        "opere_da_serramentista.porte_tagliafuoco.maniglione_antipanico",
         "opere_da_serramentista.__global__.isolamento_acustico_db",
-        "opere_da_serramentista.porte_tagliafuoco.maniglione_antipanico"
+        "opere_da_serramentista.__global__.dimensione_larghezza"
       ]
     },
     {
@@ -552,12 +453,9 @@
       "label": "Scheda Serramenti in PVC",
       "category": "Opere da serramentista|Serramenti in PVC",
       "fields": [
-        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.materiale_struttura",
-        "opere_da_serramentista.__global__.dimensione_larghezza",
-        "opere_da_serramentista.__global__.dimensione_altezza",
+        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.trasmittanza_termica",
-        "opere_da_serramentista.__global__.isolamento_acustico_db",
         "opere_da_serramentista.serramenti_in_pvc.numero_camere"
       ]
     },
@@ -566,13 +464,8 @@
       "label": "Scheda Serramenti in legno",
       "category": "Opere da serramentista|Serramenti in legno",
       "fields": [
-        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.materiale_struttura",
-        "opere_da_serramentista.__global__.dimensione_larghezza",
-        "opere_da_serramentista.__global__.dimensione_altezza",
-        "opere_da_serramentista.__global__.trasmittanza_termica",
-        "opere_da_serramentista.__global__.isolamento_acustico_db",
-        "opere_da_serramentista.serramenti_in_legno.essenza"
+        "opere_da_serramentista.__global__.marchio"
       ]
     },
     {
@@ -580,13 +473,12 @@
       "label": "Scheda Serramenti in legno e alluminio",
       "category": "Opere da serramentista|Serramenti in legno e alluminio",
       "fields": [
-        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.materiale_struttura",
-        "opere_da_serramentista.__global__.dimensione_larghezza",
-        "opere_da_serramentista.__global__.dimensione_altezza",
-        "opere_da_serramentista.__global__.trasmittanza_termica",
+        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.isolamento_acustico_db",
-        "opere_da_serramentista.serramenti_in_legno_e_alluminio.materiale_rivestimento_esterno"
+        "opere_da_serramentista.__global__.trasmittanza_termica",
+        "opere_da_serramentista.__global__.dimensione_altezza",
+        "opere_da_serramentista.__global__.dimensione_larghezza"
       ]
     },
     {
@@ -594,13 +486,13 @@
       "label": "Scheda Serramenti metallici",
       "category": "Opere da serramentista|Serramenti metallici",
       "fields": [
-        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.materiale_struttura",
-        "opere_da_serramentista.__global__.dimensione_larghezza",
-        "opere_da_serramentista.__global__.dimensione_altezza",
+        "opere_da_serramentista.__global__.marchio",
+        "opere_da_serramentista.serramenti_metallici.lega_metallo",
         "opere_da_serramentista.__global__.trasmittanza_termica",
         "opere_da_serramentista.__global__.isolamento_acustico_db",
-        "opere_da_serramentista.serramenti_metallici.lega_metallo"
+        "opere_da_serramentista.__global__.dimensione_altezza",
+        "opere_da_serramentista.__global__.dimensione_larghezza"
       ]
     },
     {
@@ -608,14 +500,12 @@
       "label": "Scheda Sistemi di partizione trasparenti, porte e parapetti vetrati",
       "category": "Opere da serramentista|Sistemi di partizione trasparenti, porte e parapetti vetrati",
       "fields": [
-        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.materiale_struttura",
-        "opere_da_serramentista.__global__.dimensione_larghezza",
+        "opere_da_serramentista.__global__.marchio",
         "opere_da_serramentista.__global__.dimensione_altezza",
-        "opere_da_serramentista.__global__.trasmittanza_termica",
         "opere_da_serramentista.__global__.isolamento_acustico_db",
         "opere_da_serramentista.sistemi_di_partizione_trasparenti_porte_e_parapetti_vetrati.tipologia_vetrata",
-        "opere_da_serramentista.sistemi_di_partizione_trasparenti_porte_e_parapetti_vetrati.classe_sicurezza_vetro"
+        "opere_da_serramentista.__global__.trasmittanza_termica"
       ]
     },
     {
@@ -624,10 +514,7 @@
       "category": "Opere da falegname|Boiserie in legno",
       "fields": [
         "opere_da_falegname.__global__.marchio",
-        "opere_da_falegname.__global__.essenza",
-        "opere_da_falegname.__global__.dimensione_larghezza",
-        "opere_da_falegname.__global__.dimensione_altezza",
-        "opere_da_falegname.__global__.tipologia_apertura"
+        "opere_da_falegname.__global__.dimensione_larghezza"
       ]
     },
     {
@@ -636,12 +523,7 @@
       "category": "Opere da falegname|Opere in legno custom",
       "fields": [
         "opere_da_falegname.__global__.marchio",
-        "opere_da_falegname.__global__.essenza",
-        "opere_da_falegname.__global__.dimensione_larghezza",
-        "opere_da_falegname.__global__.dimensione_altezza",
-        "opere_da_falegname.__global__.tipologia_apertura",
-        "opere_da_falegname.opere_in_legno_custom.descrizione_custom",
-        "opere_da_falegname.opere_in_legno_custom.destinazione_uso"
+        "opere_da_falegname.__global__.dimensione_altezza"
       ]
     },
     {
@@ -650,12 +532,7 @@
       "category": "Opere da falegname|Persiane e scuri in legno",
       "fields": [
         "opere_da_falegname.__global__.marchio",
-        "opere_da_falegname.__global__.essenza",
-        "opere_da_falegname.__global__.dimensione_larghezza",
-        "opere_da_falegname.__global__.dimensione_altezza",
-        "opere_da_falegname.__global__.tipologia_apertura",
-        "opere_da_falegname.persiane_e_scuri_in_legno.numero_ante",
-        "opere_da_falegname.persiane_e_scuri_in_legno.tipologia_lamelle"
+        "opere_da_falegname.__global__.dimensione_altezza"
       ]
     },
     {
@@ -664,11 +541,9 @@
       "category": "Opere da falegname|Porte in legno",
       "fields": [
         "opere_da_falegname.__global__.marchio",
-        "opere_da_falegname.__global__.essenza",
-        "opere_da_falegname.__global__.dimensione_larghezza",
+        "opere_da_falegname.porte_in_legno.tipologia_porta",
         "opere_da_falegname.__global__.dimensione_altezza",
-        "opere_da_falegname.__global__.tipologia_apertura",
-        "opere_da_falegname.porte_in_legno.tipologia_porta"
+        "opere_da_falegname.__global__.tipologia_apertura"
       ]
     }
   ]

--- a/pack/v1_limited/validators.json
+++ b/pack/v1_limited/validators.json
@@ -1,89 +1,137 @@
 {
   "schema": "validators/v1",
   "validators": {
-    "Opere da cartongessista|Accessori per cartongessi": {
+    "Opere da cartongessista|Pareti in cartongesso standard e idrorepellente": {
       "required": [
-        "opere_da_cartongessista.accessori_per_cartongessi.tipologia_accessorio"
-      ]
-    },
-    "Opere da cartongessista|Contropareti in cartongesso resistente al fuoco": {
-      "required": [
-        "opere_da_cartongessista.__global__.tipologia_lastra"
+        "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.tipologia_lastra",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre"
       ]
     },
     "Opere da cartongessista|Contropareti in cartongesso standard e idrorepellente": {
       "required": [
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.__global__.spessore_mm",
         "opere_da_cartongessista.__global__.tipologia_lastra"
       ]
     },
-    "Opere da cartongessista|Contropareti in lastre di fibrocemento": {
+    "Controsoffitti|Controsoffitti in fibre minerali e acustici": {
       "required": [
-        "opere_da_cartongessista.__global__.tipologia_lastra"
-      ]
-    },
-    "Opere da cartongessista|Pareti in cartongesso resistente al fuoco": {
-      "required": [
-        "opere_da_cartongessista.__global__.tipologia_lastra"
-      ]
-    },
-    "Opere da cartongessista|Pareti in cartongesso standard e idrorepellente": {
-      "required": [
-        "opere_da_cartongessista.__global__.tipologia_lastra"
-      ]
-    },
-    "Opere da cartongessista|Pareti in lastre di fibrocemento": {
-      "required": [
-        "opere_da_cartongessista.__global__.tipologia_lastra"
+        "controsoffitti.__global__.materiale"
       ]
     },
     "Opere da cartongessista|Setto autoportante cartongesso resistente al fuoco": {
       "required": [
-        "opere_da_cartongessista.__global__.tipologia_lastra"
+        "opere_da_cartongessista.__global__.tipologia_lastra",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.__global__.marchio"
       ]
     },
-    "Opere da cartongessista|Setto autoportante in cartongesso standard e idrorepellente": {
+    "Opere da cartongessista|Accessori per cartongessi": {
       "required": [
-        "opere_da_cartongessista.__global__.tipologia_lastra"
+        "opere_da_cartongessista.accessori_per_cartongessi.tipologia_accessorio",
+        "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.stratigrafia_lastre"
       ]
     },
-    "Opere di rivestimento|Altri rivestimenti": {
+    "Opere da serramentista|Porte tagliafuoco": {
       "required": [
-        "opere_di_rivestimento.__global__.materiale"
+        "opere_da_serramentista.__global__.materiale_struttura",
+        "opere_da_serramentista.__global__.marchio"
       ]
     },
-    "Opere di rivestimento|Rivestimenti in gomma o PVC": {
+    "Apparecchi sanitari e accessori|Apparecchi sanitari": {
       "required": [
-        "opere_di_rivestimento.rivestimenti_in_gomma_o_pvc.classe_antisdrucciolo"
+        "apparecchi_sanitari_e_accessori.__global__.marchio",
+        "apparecchi_sanitari_e_accessori.__global__.materiale"
       ]
     },
-    "Opere di rivestimento|Rivestimenti in gres e ceramica": {
+    "Opere da serramentista|Serramenti metallici": {
       "required": [
-        "opere_di_rivestimento.__global__.materiale"
-      ]
-    },
-    "Opere di rivestimento|Rivestimenti in legno": {
-      "required": [
-        "opere_di_rivestimento.rivestimenti_in_legno.essenza"
-      ]
-    },
-    "Opere di rivestimento|Rivestimenti in pietra": {
-      "required": [
-        "opere_di_rivestimento.rivestimenti_in_pietra.tipo_pietra"
+        "opere_da_serramentista.__global__.materiale_struttura"
       ]
     },
     "Opere di pavimentazione|Pavimentazione in autobloccanti o masselli": {
       "required": [
-        "opere_di_pavimentazione.pavimentazione_in_autobloccanti_o_masselli.tipologia_blocco"
+        "opere_di_pavimentazione.__global__.materiale",
+        "opere_di_pavimentazione.__global__.marchio"
       ]
     },
-    "Opere di pavimentazione|Pavimenti in altri materiali": {
+    "Opere da falegname|Porte in legno": {
       "required": [
-        "opere_di_pavimentazione.__global__.materiale"
+        "opere_da_falegname.__global__.marchio"
+      ]
+    },
+    "Controsoffitti|Controsoffitti in cartongesso": {
+      "required": [
+        "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.stratigrafia_lastre",
+        "controsoffitti.__global__.marchio"
+      ]
+    },
+    "Opere da serramentista|Serramenti in legno": {
+      "required": [
+        "opere_da_serramentista.__global__.materiale_struttura",
+        "opere_da_serramentista.__global__.marchio"
+      ]
+    },
+    "Opere da serramentista|Serramenti in legno e alluminio": {
+      "required": [
+        "opere_da_serramentista.__global__.materiale_struttura",
+        "opere_da_serramentista.__global__.marchio"
       ]
     },
     "Opere di pavimentazione|Pavimenti in gomma o PVC": {
       "required": [
-        "opere_di_pavimentazione.pavimenti_in_gomma_o_pvc.classe_emissione"
+        "opere_di_pavimentazione.__global__.materiale"
+      ]
+    },
+    "Controsoffitti|Controsoffitti metallici": {
+      "required": [
+        "controsoffitti.__global__.materiale"
+      ]
+    },
+    "Opere di pavimentazione|Pavimenti in pietra": {
+      "required": [
+        "opere_di_pavimentazione.__global__.materiale"
+      ]
+    },
+    "Opere di pavimentazione|Pavimenti industriali": {
+      "required": [
+        "opere_di_pavimentazione.__global__.materiale"
+      ]
+    },
+    "Opere di rivestimento|Altri rivestimenti": {
+      "required": [
+        "opere_di_rivestimento.__global__.materiale",
+        "opere_di_rivestimento.__global__.marchio"
+      ]
+    },
+    "Opere di pavimentazione|Zoccolini e accessori per pavimentazioni": {
+      "required": [
+        "opere_di_pavimentazione.__global__.materiale"
+      ]
+    },
+    "Opere da serramentista|Avvolgibili, controtelai, cassonetti e persiane": {
+      "required": [
+        "opere_da_serramentista.__global__.materiale_struttura"
+      ]
+    },
+    "Apparecchi sanitari e accessori|Cassette di scarico": {
+      "required": [
+        "apparecchi_sanitari_e_accessori.cassette_di_scarico.tipologia_cassetta",
+        "apparecchi_sanitari_e_accessori.__global__.materiale",
+        "apparecchi_sanitari_e_accessori.__global__.marchio"
+      ]
+    },
+    "Opere da falegname|Opere in legno custom": {
+      "required": [
+        "opere_da_falegname.__global__.marchio"
+      ]
+    },
+    "Opere di rivestimento|Rivestimenti in gomma o PVC": {
+      "required": [
+        "opere_di_rivestimento.__global__.materiale"
       ]
     },
     "Opere di pavimentazione|Pavimenti in gres e ceramica": {
@@ -93,157 +141,138 @@
     },
     "Opere di pavimentazione|Pavimenti in legno e laminato": {
       "required": [
-        "opere_di_pavimentazione.pavimenti_in_legno_e_laminato.essenza"
-      ]
-    },
-    "Opere di pavimentazione|Pavimenti in moquette e zerbini": {
-      "required": [
-        "opere_di_pavimentazione.pavimenti_in_moquette_e_zerbini.tipologia_fibra"
-      ]
-    },
-    "Opere di pavimentazione|Pavimenti in pietra": {
-      "required": [
-        "opere_di_pavimentazione.pavimenti_in_pietra.tipo_pietra"
-      ]
-    },
-    "Opere di pavimentazione|Pavimenti industriali": {
-      "required": [
         "opere_di_pavimentazione.__global__.materiale"
       ]
     },
-    "Opere di pavimentazione|Pavimenti sopraelevati e flottanti": {
+    "Apparecchi sanitari e accessori|Accessori per l'allestimento di servizi igienici": {
       "required": [
-        "opere_di_pavimentazione.pavimenti_sopraelevati_e_flottanti.tipologia_struttura"
+        "apparecchi_sanitari_e_accessori.__global__.marchio"
       ]
     },
-    "Opere di pavimentazione|Zoccolini e accessori per pavimentazioni": {
+    "Opere di rivestimento|Rivestimenti in legno": {
       "required": [
-        "opere_di_pavimentazione.zoccolini_e_accessori_per_pavimentazioni.tipologia_zoccolino"
-      ]
-    },
-    "Opere da serramentista|Avvolgibili, controtelai, cassonetti e persiane": {
-      "required": [
-        "opere_da_serramentista.avvolgibili_controtelai_cassonetti_e_persiane.tipologia_avvolgibile"
-      ]
-    },
-    "Opere da serramentista|Porte blindate, portoni e bussole": {
-      "required": [
-        "opere_da_serramentista.porte_blindate_portoni_e_bussole.classe_antieffrazione"
-      ]
-    },
-    "Opere da serramentista|Porte metalliche": {
-      "required": [
-        "opere_da_serramentista.__global__.materiale_struttura"
-      ]
-    },
-    "Opere da serramentista|Porte tagliafuoco": {
-      "required": [
-        "opere_da_serramentista.porte_tagliafuoco.maniglione_antipanico"
-      ]
-    },
-    "Opere da serramentista|Serramenti in PVC": {
-      "required": [
-        "opere_da_serramentista.serramenti_in_pvc.numero_camere"
-      ]
-    },
-    "Opere da serramentista|Serramenti in legno": {
-      "required": [
-        "opere_da_serramentista.serramenti_in_legno.essenza"
-      ]
-    },
-    "Opere da serramentista|Serramenti in legno e alluminio": {
-      "required": [
-        "opere_da_serramentista.serramenti_in_legno_e_alluminio.materiale_rivestimento_esterno"
-      ]
-    },
-    "Opere da serramentista|Serramenti metallici": {
-      "required": [
-        "opere_da_serramentista.serramenti_metallici.lega_metallo"
-      ]
-    },
-    "Opere da serramentista|Sistemi di partizione trasparenti, porte e parapetti vetrati": {
-      "required": [
-        "opere_da_serramentista.sistemi_di_partizione_trasparenti_porte_e_parapetti_vetrati.tipologia_vetrata"
+        "opere_di_rivestimento.__global__.spessore_mm",
+        "opere_di_rivestimento.__global__.materiale",
+        "opere_di_rivestimento.__global__.marchio"
       ]
     },
     "Controsoffitti|Botole d'ispezione e accessori": {
-      "required": [
-        "controsoffitti.botole_d_ispezione_e_accessori.dimensione_botola_mm"
-      ]
-    },
-    "Controsoffitti|Controsoffitti a Baffles e ispezionabili": {
-      "required": [
-        "controsoffitti.controsoffitti_a_baffles_e_ispezionabili.passo_baffles_mm"
-      ]
-    },
-    "Controsoffitti|Controsoffitti a doghe in legno": {
       "required": [
         "controsoffitti.__global__.materiale"
       ]
     },
     "Controsoffitti|Controsoffitti in PVC o materiali plastici": {
       "required": [
-        "controsoffitti.controsoffitti_in_pvc_o_materiali_plastici.resistenza_umidita"
-      ]
-    },
-    "Controsoffitti|Controsoffitti in altri materiali": {
-      "required": [
         "controsoffitti.__global__.materiale"
       ]
     },
-    "Controsoffitti|Controsoffitti in cartongesso": {
+    "Opere da serramentista|Serramenti in PVC": {
       "required": [
-        "controsoffitti.__global__.materiale"
+        "opere_da_serramentista.__global__.materiale_struttura"
       ]
     },
-    "Controsoffitti|Controsoffitti in fibre minerali e acustici": {
+    "Opere di rivestimento|Rivestimenti in gres e ceramica": {
       "required": [
-        "controsoffitti.__global__.coefficiente_fonoassorbimento"
+        "opere_di_rivestimento.__global__.materiale"
       ]
     },
-    "Controsoffitti|Controsoffitti metallici": {
+    "Opere da serramentista|Sistemi di partizione trasparenti, porte e parapetti vetrati": {
       "required": [
-        "controsoffitti.__global__.materiale"
+        "opere_da_serramentista.__global__.materiale_struttura",
+        "opere_da_serramentista.__global__.marchio"
       ]
     },
     "Controsoffitti|Velette di raccordo": {
       "required": [
-        "controsoffitti.__global__.materiale"
+        "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.marchio",
+        "controsoffitti.__global__.stratigrafia_lastre"
       ]
     },
-    "Apparecchi sanitari e accessori|Accessori per l'allestimento di servizi igienici": {
+    "Opere da cartongessista|Pareti in cartongesso resistente al fuoco": {
       "required": [
-        "apparecchi_sanitari_e_accessori.accessori_per_l_allestimento_di_servizi_igienici.tipologia_accessorio"
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.__global__.marchio",
+        "opere_da_cartongessista.__global__.tipologia_lastra"
       ]
     },
-    "Apparecchi sanitari e accessori|Apparecchi sanitari": {
+    "Controsoffitti|Controsoffitti in altri materiali": {
       "required": [
-        "apparecchi_sanitari_e_accessori.apparecchi_sanitari.tipologia_apparecchio"
+        "controsoffitti.__global__.spessore_pannello_mm",
+        "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.marchio"
       ]
     },
-    "Apparecchi sanitari e accessori|Cassette di scarico": {
+    "Opere da cartongessista|Setto autoportante in cartongesso standard e idrorepellente": {
       "required": [
-        "apparecchi_sanitari_e_accessori.cassette_di_scarico.tipologia_cassetta"
+        "opere_da_cartongessista.__global__.tipologia_lastra",
+        "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.marchio"
       ]
     },
-    "Opere da falegname|Boiserie in legno": {
+    "Opere da cartongessista|Contropareti in cartongesso resistente al fuoco": {
       "required": [
-        "opere_da_falegname.__global__.essenza"
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.marchio"
       ]
     },
-    "Opere da falegname|Opere in legno custom": {
+    "Opere di pavimentazione|Pavimenti in moquette e zerbini": {
       "required": [
-        "opere_da_falegname.opere_in_legno_custom.descrizione_custom"
+        "opere_di_pavimentazione.__global__.materiale"
       ]
     },
-    "Opere da falegname|Persiane e scuri in legno": {
+    "Opere da serramentista|Porte metalliche": {
       "required": [
-        "opere_da_falegname.persiane_e_scuri_in_legno.numero_ante"
+        "opere_da_serramentista.__global__.materiale_struttura",
+        "opere_da_serramentista.__global__.marchio",
+        "opere_da_serramentista.__global__.dimensione_altezza"
       ]
     },
-    "Opere da falegname|Porte in legno": {
+    "Opere di pavimentazione|Pavimenti sopraelevati e flottanti": {
       "required": [
-        "opere_da_falegname.porte_in_legno.tipologia_porta"
+        "opere_di_pavimentazione.__global__.materiale"
+      ]
+    },
+    "Opere da serramentista|Porte blindate, portoni e bussole": {
+      "required": [
+        "opere_da_serramentista.__global__.materiale_struttura"
+      ]
+    },
+    "Controsoffitti|Controsoffitti a Baffles e ispezionabili": {
+      "required": [
+        "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.marchio"
+      ]
+    },
+    "Opere di rivestimento|Rivestimenti in pietra": {
+      "required": [
+        "opere_di_rivestimento.__global__.materiale"
+      ]
+    },
+    "Opere di pavimentazione|Pavimenti in altri materiali": {
+      "required": [
+        "opere_di_pavimentazione.__global__.materiale"
+      ]
+    },
+    "Opere da cartongessista|Contropareti in lastre di fibrocemento": {
+      "required": [
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.marchio"
+      ]
+    },
+    "Opere da cartongessista|Pareti in lastre di fibrocemento": {
+      "required": [
+        "opere_da_cartongessista.__global__.stratigrafia_lastre",
+        "opere_da_cartongessista.__global__.spessore_mm",
+        "opere_da_cartongessista.__global__.marchio"
+      ]
+    },
+    "Controsoffitti|Controsoffitti a doghe in legno": {
+      "required": [
+        "controsoffitti.__global__.materiale",
+        "controsoffitti.__global__.marchio"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- add a lim dataset coverage snapshot to document slot completeness and support future curation
- trim v1_limited templates to drop never-populated slots and prioritise the fields that actually appear in the dataset
- relax validators to require only high-coverage attributes for each category, reflecting the converted lim data

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbd69f15d88322a4f99ec3c7444752