### PR TITLE
Restore legacy extractor pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,19 @@
-.gitignore
-.vscode
-outputs
+# Project ignores
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# Environment files
+*.env
+.venv/
+
+# Editor configuration
+.vscode/
+.idea/
+
+# Generated outputs
+outputs/
+
+# Miscellaneous
 commands.txt

--- a/pack/current/extractors.json
+++ b/pack/current/extractors.json
@@ -1,0 +1,272 @@
+{
+  "metadata": {
+    "version": "0.1.0",
+    "description": "Fallback regex patterns reconstructed from data/properties",
+    "source": "data/properties"
+  },
+  "defaults": {
+    "normalizers": [
+      "strip",
+      "collapse_spaces"
+    ],
+    "flags": [
+      "IGNORECASE",
+      "MULTILINE"
+    ]
+  },
+  "patterns": [
+    {
+      "property_id": "marchio",
+      "regex": [
+        "(?:marchio|brand|produttore)[:\\s]+(?P<value>[A-Z0-9][\\w\\-&/ ]{2,})",
+        "(?<![A-Za-zÀ-ÿ0-9])(?P<value>[A-Z][A-Za-z0-9&\\-]{2,}(?:\\s+[A-Z][A-Za-z0-9&\\-]{2,}){0,2})(?![a-zà-ÿ])"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces"
+      ]
+    },
+    {
+      "property_id": "tipologia_lastra",
+      "regex": [
+        "(?:tipologia(?:\\s+di)?\\s+lastra|tipo\\s+lastra)[:\\s]+(?P<value>[A-Za-zÀ-ÿ\\s_-]{3,})",
+        "(?P<value>standard|idrofuga|ignifuga|acustica|fibrogesso|accoppiata\\s*isolante)"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces",
+        "lower"
+      ]
+    },
+    {
+      "property_id": "spessore_mm",
+      "regex": [
+        "(?:spessore|thickness)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>mm|millimetri|cm|centimetri|m|metri)?",
+        "(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>mm|millimetri|cm|centimetri|m|metri)"
+      ],
+      "normalizers": [
+        "to_mm"
+      ]
+    },
+    {
+      "property_id": "classe_ei",
+      "regex": [
+        "(?:classe\\s*ei|ei)[:\\s]*(?P<value>EI\\s*\\d{1,3})",
+        "(?P<value>EI\\s*\\d{1,3})"
+      ],
+      "normalizers": [
+        "normalize_ei"
+      ]
+    },
+    {
+      "property_id": "classe_reazione_al_fuoco",
+      "regex": [
+        "(?:reazione\\s+al\\s+fuoco|classe\\s+di\\s+reazione)[:\\s]*(?P<value>[A-F][^\\s,;:]{0,6})",
+        "(?P<value>[A-F][0-3]?(?:-s\\d(?:,d\\d)?)?)"
+      ],
+      "normalizers": [
+        "normalize_fire_reaction"
+      ]
+    },
+    {
+      "property_id": "presenza_isolante",
+      "regex": [
+        "(?:presenza\\s+isolante|isolante)[:\\s]+(?P<value>s[iì]|no)"
+      ],
+      "normalizers": [
+        "to_bool_strict"
+      ]
+    },
+    {
+      "property_id": "stratigrafia_lastre",
+      "regex": [
+        "stratigrafia[:\\s]+(?P<value>[^\\n]+)",
+        "composizione[:\\s]+(?P<value>[^\\n]+)"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces"
+      ]
+    },
+    {
+      "property_id": "materiale",
+      "regex": [
+        "(?:materiale|materiali)[:\\s]+(?P<value>[A-Za-zÀ-ÿ0-9\\s\\-_/]+)",
+        "in\\s+(?P<value>legno|acciaio|alluminio|gesso|cartongesso|ceramica|pvc|vetroresina|lana\\s*di\\s*roccia)"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces",
+        "lower"
+      ]
+    },
+    {
+      "property_id": "finitura",
+      "regex": [
+        "finitura[:\\s]+(?P<value>[^\\n;,]+)"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces"
+      ]
+    },
+    {
+      "property_id": "posa",
+      "regex": [
+        "posa[:\\s]+(?P<value>[^\\n;,]+)"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces"
+      ]
+    },
+    {
+      "property_id": "formato",
+      "regex": [
+        "(?:formato|dimensioni?)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?\\s*[x×]\\s*\\d+(?:[.,]\\d+)?(?:\\s*[x×]\\s*\\d+(?:[.,]\\d+)?)?)(?:\\s*(?P<unit>mm|cm|m))?"
+      ],
+      "normalizers": [
+        "normalize_format"
+      ]
+    },
+    {
+      "property_id": "classe_resistenza_usura",
+      "regex": [
+        "(?:classe\\s+resistenza\\s+usura|classe\\s+di\\s+usura|pei)[:\\s]*(?P<value>(?:pei\\s*)?[ivx0-9]{1,3})",
+        "(?P<value>PEI\\s*[IVX0-5])"
+      ],
+      "normalizers": [
+        "normalize_pei"
+      ]
+    },
+    {
+      "property_id": "classe_scivolosita",
+      "regex": [
+        "(?:classe\\s+scivolosità|antiscivolo|scivolosità)[:\\s]*(?P<value>[A-Z]{1,2}\\d{0,2}(?:-?R\\d{1,2})?)",
+        "(?P<value>R\\d{9})",
+        "(?P<value>R\\d{1,2})"
+      ],
+      "normalizers": [
+        "normalize_slip_class"
+      ]
+    },
+    {
+      "property_id": "materiale_struttura",
+      "regex": [
+        "(?:materiale\\s+struttura|struttura)[:\\s]+(?P<value>[A-Za-zÀ-ÿ0-9\\s\\-_/]+)"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces",
+        "lower"
+      ]
+    },
+    {
+      "property_id": "dimensione_larghezza",
+      "regex": [
+        "(?:larghezza|dimensione\\s+larghezza|l\\.)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>mm|millimetri|cm|centimetri|m|metri)"
+      ],
+      "normalizers": [
+        "to_mm"
+      ]
+    },
+    {
+      "property_id": "dimensione_altezza",
+      "regex": [
+        "(?:altezza|dimensione\\s+altezza|h\\.)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>mm|millimetri|cm|centimetri|m|metri)"
+      ],
+      "normalizers": [
+        "to_mm"
+      ]
+    },
+    {
+      "property_id": "trasmittanza_termica",
+      "regex": [
+        "(?:trasmittanza\\s+termica|u\\s*-?value)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>w/m²k|w/m2k|w/mk)?",
+        "(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>w/m²k|w/m2k|w/mk)"
+      ],
+      "normalizers": [
+        "to_number"
+      ]
+    },
+    {
+      "property_id": "isolamento_acustico_db",
+      "regex": [
+        "(?:isolamento\\s+acustico|abbattimento\\s+acustico|potere\\s+fonoisolante)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>dB|db|decibel)?",
+        "(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>dB|db)"
+      ],
+      "normalizers": [
+        "to_number"
+      ]
+    },
+    {
+      "property_id": "spessore_pannello_mm",
+      "regex": [
+        "(?:spessore\\s+pannello|pannello\\s+spessore)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>mm|millimetri|cm|centimetri|m|metri)"
+      ],
+      "normalizers": [
+        "to_mm"
+      ]
+    },
+    {
+      "property_id": "coefficiente_fonoassorbimento",
+      "regex": [
+        "(?:coefficiente\\s+fonoassorbimento|alpha\\s*w)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?)"
+      ],
+      "normalizers": [
+        "to_number"
+      ]
+    },
+    {
+      "property_id": "dimensione_lunghezza",
+      "regex": [
+        "(?:lunghezza|dimensione\\s+lunghezza|l\\.)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>mm|millimetri|cm|centimetri|m|metri)"
+      ],
+      "normalizers": [
+        "to_mm"
+      ]
+    },
+    {
+      "property_id": "tipologia_installazione",
+      "regex": [
+        "(?:tipologia\\s+installazione|installazione)[:\\s]+(?P<value>[^\\n;,]+)"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces",
+        "lower"
+      ]
+    },
+    {
+      "property_id": "portata_l_min",
+      "regex": [
+        "(?:portata|flusso)[:\\s]+(?P<value>\\d+(?:[.,]\\d+)?)\\s*(?P<unit>l/min|lpm|litri/min(?:uto)?)"
+      ],
+      "normalizers": [
+        "to_number"
+      ]
+    },
+    {
+      "property_id": "essenza",
+      "regex": [
+        "essenza[:\\s]+(?P<value>[A-Za-zÀ-ÿ\\s\\-]+)"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces",
+        "lower"
+      ]
+    },
+    {
+      "property_id": "tipologia_apertura",
+      "regex": [
+        "(?:tipologia\\s+apertura|apertura)[:\\s]+(?P<value>[^\\n;,]+)"
+      ],
+      "normalizers": [
+        "strip",
+        "collapse_spaces",
+        "lower"
+      ]
+    }
+  ]
+}

--- a/pack/current/registry.json
+++ b/pack/current/registry.json
@@ -1,0 +1,474 @@
+{
+  "$schema": "https://raw.githubusercontent.com/frank1beans/roBERT/main/schemas/property-registry-v1.json",
+  "metadata": {
+    "version": "0.2.0",
+    "generated_at": "2024-12-01T00:00:00Z",
+    "categories": 7,
+    "description": "Schema-first registry aligned with pack/v1_limited categories"
+  },
+  "categories": [
+    {
+      "id": "opere_da_cartongessista",
+      "name": "Opere da cartongessista",
+      "schema": "schema/opere_da_cartongessista.json",
+      "required": [
+        "tipologia_lastra",
+        "spessore_mm",
+        "classe_reazione_al_fuoco"
+      ],
+      "properties": [
+        {
+          "id": "marchio",
+          "title": "Marchio",
+          "type": "string",
+          "description": "Brand dichiarato nel testo",
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "tipologia_lastra",
+          "title": "Tipologia lastra",
+          "type": "string",
+          "description": "Tipologia di lastra in cartongesso",
+          "enum": [
+            "standard",
+            "idrofuga",
+            "ignifuga",
+            "acustica",
+            "fibrogesso",
+            "accoppiata_isolante"
+          ],
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "spessore_mm",
+          "title": "Spessore sistema",
+          "type": "number",
+          "unit": "mm",
+          "description": "Spessore complessivo del sistema convertito in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "classe_ei",
+          "title": "Classe EI",
+          "type": "string",
+          "description": "Classe di resistenza al fuoco EI",
+          "enum": ["EI30", "EI45", "EI60", "EI90", "EI120", "EI180"],
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "classe_reazione_al_fuoco",
+          "title": "Classe di reazione al fuoco",
+          "type": "string",
+          "description": "Classe europea di reazione al fuoco",
+          "enum": ["A1", "A2-s1,d0", "A2-s2,d0", "B-s1,d0", "B-s2,d0"],
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "presenza_isolante",
+          "title": "Presenza isolante",
+          "type": "string",
+          "description": "Indica se è presente materiale isolante accoppiato",
+          "enum": ["si", "no"],
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "stratigrafia_lastre",
+          "title": "Stratigrafia lastre",
+          "type": "string",
+          "description": "Descrizione testuale della stratigrafia delle lastre",
+          "sources": ["qa_llm"]
+        }
+      ]
+    },
+    {
+      "id": "opere_di_rivestimento",
+      "name": "Opere di rivestimento",
+      "schema": "schema/opere_di_rivestimento.json",
+      "required": [
+        "materiale",
+        "spessore_mm",
+        "posa"
+      ],
+      "properties": [
+        {
+          "id": "marchio",
+          "title": "Marchio",
+          "type": "string",
+          "description": "Brand dichiarato nel testo",
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "materiale",
+          "title": "Materiale",
+          "type": "string",
+          "description": "Materiale principale del rivestimento",
+          "enum": [
+            "gres",
+            "pietra",
+            "ceramica",
+            "legno",
+            "resina",
+            "intonaco",
+            "laminato",
+            "metallo"
+          ],
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "finitura",
+          "title": "Finitura",
+          "type": "string",
+          "description": "Finitura superficiale o trattamento",
+          "sources": ["qa_llm"]
+        },
+        {
+          "id": "spessore_mm",
+          "title": "Spessore",
+          "type": "number",
+          "unit": "mm",
+          "description": "Spessore del rivestimento convertito in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "posa",
+          "title": "Tipologia di posa",
+          "type": "string",
+          "description": "Modalità di posa prevista",
+          "enum": ["incollata", "flottante", "a secco", "meccanica", "su struttura"],
+          "sources": ["qa_llm"]
+        },
+        {
+          "id": "classe_reazione_al_fuoco",
+          "title": "Classe di reazione al fuoco",
+          "type": "string",
+          "description": "Classe europea di reazione al fuoco",
+          "enum": ["A1", "A2-s1,d0", "B-s1,d0", "C-s1,d0"],
+          "sources": ["parser", "qa_llm"]
+        }
+      ]
+    },
+    {
+      "id": "opere_di_pavimentazione",
+      "name": "Opere di pavimentazione",
+      "schema": "schema/opere_di_pavimentazione.json",
+      "required": [
+        "materiale",
+        "formato",
+        "spessore_mm"
+      ],
+      "properties": [
+        {
+          "id": "marchio",
+          "title": "Marchio",
+          "type": "string",
+          "description": "Brand dichiarato nel testo",
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "materiale",
+          "title": "Materiale",
+          "type": "string",
+          "description": "Materiale principale del pavimento",
+          "enum": [
+            "gres",
+            "legno",
+            "laminato",
+            "resina",
+            "pietra_naturale",
+            "calcestruzzo",
+            "vinilico"
+          ],
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "formato",
+          "title": "Formato",
+          "type": "string",
+          "description": "Formato nominale delle lastre o doghe",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "spessore_mm",
+          "title": "Spessore",
+          "type": "number",
+          "unit": "mm",
+          "description": "Spessore del pavimento convertito in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "classe_resistenza_usura",
+          "title": "Classe resistenza usura",
+          "type": "string",
+          "description": "Classe PEI dichiarata",
+          "enum": ["PEI I", "PEI II", "PEI III", "PEI IV", "PEI V"],
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "classe_scivolosita",
+          "title": "Classe di scivolosità",
+          "type": "string",
+          "description": "Classe antiscivolo (R)",
+          "enum": ["R9", "R10", "R11", "R12", "R13"],
+          "sources": ["parser", "qa_llm"]
+        }
+      ]
+    },
+    {
+      "id": "opere_da_serramentista",
+      "name": "Opere da serramentista",
+      "schema": "schema/opere_da_serramentista.json",
+      "required": [
+        "dimensione_larghezza",
+        "dimensione_altezza",
+        "trasmittanza_termica"
+      ],
+      "properties": [
+        {
+          "id": "marchio",
+          "title": "Marchio",
+          "type": "string",
+          "description": "Brand del serramento",
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "materiale_struttura",
+          "title": "Materiale struttura",
+          "type": "string",
+          "description": "Materiale principale della struttura",
+          "enum": ["alluminio", "acciaio", "legno", "pvc", "legno_alluminio"],
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "dimensione_larghezza",
+          "title": "Larghezza luce",
+          "type": "number",
+          "unit": "mm",
+          "description": "Larghezza netta in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "dimensione_altezza",
+          "title": "Altezza luce",
+          "type": "number",
+          "unit": "mm",
+          "description": "Altezza netta in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "trasmittanza_termica",
+          "title": "Trasmittanza termica",
+          "type": "number",
+          "unit": "W/m²K",
+          "description": "Valore Uw dichiarato",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "isolamento_acustico_db",
+          "title": "Isolamento acustico Rw",
+          "type": "number",
+          "unit": "dB",
+          "description": "Valore Rw o Rw+C",
+          "sources": ["parser", "qa_llm"]
+        }
+      ]
+    },
+    {
+      "id": "controsoffitti",
+      "name": "Controsoffitti",
+      "schema": "schema/controsoffitti.json",
+      "required": [
+        "materiale",
+        "spessore_pannello_mm",
+        "coefficiente_fonoassorbimento"
+      ],
+      "properties": [
+        {
+          "id": "marchio",
+          "title": "Marchio",
+          "type": "string",
+          "description": "Brand del sistema di controsoffitto",
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "materiale",
+          "title": "Materiale",
+          "type": "string",
+          "description": "Materiale principale del pannello",
+          "enum": [
+            "acciaio",
+            "alluminio",
+            "cartongesso",
+            "lana_minerale",
+            "fibra_minerale"
+          ],
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "spessore_pannello_mm",
+          "title": "Spessore pannello",
+          "type": "number",
+          "unit": "mm",
+          "description": "Spessore del pannello convertito in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "classe_reazione_al_fuoco",
+          "title": "Classe di reazione al fuoco",
+          "type": "string",
+          "description": "Classe europea di reazione al fuoco",
+          "enum": ["A1", "A2-s1,d0", "B-s1,d0", "B-s2,d0"],
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "coefficiente_fonoassorbimento",
+          "title": "Coefficiente di fonoassorbimento",
+          "type": "number",
+          "description": "Valore αw (0-1)",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "stratigrafia_lastre",
+          "title": "Stratigrafia lastre",
+          "type": "string",
+          "description": "Descrizione stratigrafia o composizione",
+          "sources": ["qa_llm"]
+        }
+      ]
+    },
+    {
+      "id": "apparecchi_sanitari_accessori",
+      "name": "Apparecchi sanitari e accessori",
+      "schema": "schema/apparecchi_sanitari_accessori.json",
+      "required": [
+        "materiale",
+        "dimensione_lunghezza",
+        "dimensione_larghezza",
+        "dimensione_altezza",
+        "tipologia_installazione"
+      ],
+      "properties": [
+        {
+          "id": "marchio",
+          "title": "Marchio",
+          "type": "string",
+          "description": "Brand dell'apparecchio sanitario",
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "materiale",
+          "title": "Materiale",
+          "type": "string",
+          "description": "Materiale principale",
+          "enum": [
+            "ceramica",
+            "acciaio_inox",
+            "resina",
+            "vetro",
+            "ghisa",
+            "porcellana"
+          ],
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "dimensione_lunghezza",
+          "title": "Lunghezza",
+          "type": "number",
+          "unit": "mm",
+          "description": "Lunghezza nominale convertita in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "dimensione_larghezza",
+          "title": "Larghezza",
+          "type": "number",
+          "unit": "mm",
+          "description": "Larghezza nominale convertita in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "dimensione_altezza",
+          "title": "Altezza",
+          "type": "number",
+          "unit": "mm",
+          "description": "Altezza nominale convertita in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "tipologia_installazione",
+          "title": "Tipologia installazione",
+          "type": "string",
+          "description": "Modalità di installazione",
+          "enum": ["a_pavimento", "a_parete", "sospesa", "incasso"],
+          "sources": ["qa_llm"]
+        },
+        {
+          "id": "portata_l_min",
+          "title": "Portata",
+          "type": "number",
+          "unit": "l/min",
+          "description": "Portata dichiarata in litri al minuto",
+          "sources": ["parser", "qa_llm"]
+        }
+      ]
+    },
+    {
+      "id": "opere_da_falegname",
+      "name": "Opere da falegname",
+      "schema": "schema/opere_da_falegname.json",
+      "required": [
+        "essenza",
+        "dimensione_larghezza",
+        "dimensione_altezza"
+      ],
+      "properties": [
+        {
+          "id": "marchio",
+          "title": "Marchio",
+          "type": "string",
+          "description": "Brand del manufatto",
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "essenza",
+          "title": "Essenza",
+          "type": "string",
+          "description": "Essenza legnosa principale",
+          "enum": [
+            "rovere",
+            "faggio",
+            "pino",
+            "abete",
+            "larice",
+            "noce",
+            "castagno"
+          ],
+          "sources": ["matcher", "qa_llm"]
+        },
+        {
+          "id": "dimensione_larghezza",
+          "title": "Larghezza",
+          "type": "number",
+          "unit": "mm",
+          "description": "Larghezza finita in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "dimensione_altezza",
+          "title": "Altezza",
+          "type": "number",
+          "unit": "mm",
+          "description": "Altezza finita in millimetri",
+          "sources": ["parser", "qa_llm"]
+        },
+        {
+          "id": "tipologia_apertura",
+          "title": "Tipologia apertura",
+          "type": "string",
+          "description": "Sistema di apertura del serramento",
+          "enum": ["battente", "scorrevole", "a_ribalta", "a_scomparsa", "anta_ribalta"],
+          "sources": ["qa_llm"]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/sanity_check.py
+++ b/scripts/sanity_check.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Utility to verify the repository has the expected structure and passes tests."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REQUIRED_PATHS = [
+    Path("pyproject.toml"),
+    Path("src"),
+    Path("src/robimb"),
+    Path("tests"),
+    Path("docs"),
+    Path("data"),
+]
+
+
+def find_missing(paths: Iterable[Path]) -> list[Path]:
+    """Return the paths that are not present in the repository."""
+    return [path for path in paths if not path.exists()]
+
+
+def run_pytest(pytest_args: list[str] | None = None) -> int:
+    """Execute pytest with the provided arguments and return its exit code."""
+    cmd = [sys.executable, "-m", "pytest"]
+    if pytest_args:
+        cmd.extend(pytest_args)
+    process = subprocess.run(cmd, check=False)
+    return process.returncode
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skip-tests",
+        action="store_true",
+        help="Skip running the pytest suite.",
+    )
+    parser.add_argument(
+        "pytest-args",
+        nargs=argparse.REMAINDER,
+        help="Arguments passed directly to pytest (must come after --).",
+    )
+    args = parser.parse_args(argv)
+
+    missing = find_missing(REQUIRED_PATHS)
+    if missing:
+        print("Missing required paths:")
+        for path in missing:
+            print(f" - {path}")
+    else:
+        print("All required paths are present.")
+
+    exit_code = 0
+    if not args.skip_tests:
+        pytest_args = args.__dict__.get("pytest-args") or []
+        if pytest_args and pytest_args[0] == "--":
+            pytest_args = pytest_args[1:]
+        print("\nRunning pytest...")
+        exit_code = run_pytest(pytest_args)
+        if exit_code == 0:
+            print("Pytest completed successfully.")
+        else:
+            print(f"Pytest exited with code {exit_code}.")
+
+    if missing and exit_code == 0:
+        return 1
+    if missing or exit_code != 0:
+        return exit_code or 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/robimb/extraction/legacy.py
+++ b/src/robimb/extraction/legacy.py
@@ -1,0 +1,473 @@
+"""Regex-based property extraction engine used for backwards compatibility.
+
+This module rebuilds the legacy regex matcher so that existing
+utilities such as dataset conversion can continue to operate.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+__all__ = [
+    "Pattern",
+    "extract_properties",
+    "dry_run",
+    "validate_extractors_pack",
+]
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Pattern:
+    """Compiled representation of a property extraction rule."""
+
+    property_id: str
+    regexes: Tuple[re.Pattern[str], ...]
+    tags: Tuple[str, ...]
+    normalizers: Tuple[str, ...]
+    collect_many: bool = False
+    priority: int = 0
+
+    def matches_tags(self, target_tags: Optional[Sequence[str]]) -> bool:
+        if not self.tags:
+            return True
+        if not target_tags:
+            return False
+        target = {tag.lower() for tag in target_tags}
+        return all(tag.lower() in target for tag in self.tags)
+
+
+Flag = int
+
+_FLAG_ALIASES: Mapping[str, Flag] = {
+    "IGNORECASE": re.IGNORECASE,
+    "MULTILINE": re.MULTILINE,
+    "DOTALL": re.DOTALL,
+}
+
+_DEFAULT_FLAGS = re.IGNORECASE | re.MULTILINE
+
+
+def _ensure_sequence(value: Any) -> Tuple[Any, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple, set)):
+        return tuple(value)
+    return (value,)
+
+
+def _compile_regex(pattern: str, flags: Flag) -> re.Pattern[str]:
+    return re.compile(pattern, flags)
+
+
+def _normalize_pattern_spec(spec: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
+    property_id = spec.get("property_id") or spec.get("property") or spec.get("id")
+    if not isinstance(property_id, str) or not property_id:
+        return None
+    regexes: List[str] = []
+    for key in ("regex", "pattern", "patterns", "expressions"):
+        raw = spec.get(key)
+        if isinstance(raw, str):
+            regexes.append(raw)
+        elif isinstance(raw, Sequence):
+            regexes.extend(str(item) for item in raw if isinstance(item, (str, bytes)))
+        if regexes:
+            break
+    if not regexes:
+        return None
+    tags = [tag for tag in _ensure_sequence(spec.get("tags")) if isinstance(tag, str)]
+    normalizers = [
+        name for name in _ensure_sequence(spec.get("normalizers")) if isinstance(name, str) and name
+    ]
+    collect_many = bool(spec.get("collect_many") or spec.get("collectMany"))
+    priority = int(spec.get("priority", 0))
+    return {
+        "property_id": property_id,
+        "regex": regexes,
+        "tags": tags,
+        "normalizers": normalizers,
+        "collect_many": collect_many,
+        "priority": priority,
+    }
+
+
+def _compile_patterns(
+    pack: Mapping[str, Any],
+    allowed_properties: Optional[Sequence[str]],
+    target_tags: Optional[Sequence[str]],
+) -> Tuple[Pattern, ...]:
+    defaults = pack.get("defaults") if isinstance(pack, Mapping) else None
+    default_norms = []
+    default_flags = _DEFAULT_FLAGS
+    default_collect_many = False
+    if isinstance(defaults, Mapping):
+        default_norms = [
+            name for name in _ensure_sequence(defaults.get("normalizers")) if isinstance(name, str) and name
+        ]
+        raw_flags = _ensure_sequence(defaults.get("flags"))
+        flags_value = 0
+        for item in raw_flags:
+            if isinstance(item, str) and item.upper() in _FLAG_ALIASES:
+                flags_value |= _FLAG_ALIASES[item.upper()]
+            elif isinstance(item, int):
+                flags_value |= int(item)
+        if flags_value:
+            default_flags = flags_value
+        default_collect_many = bool(defaults.get("collect_many"))
+
+    allowed: Optional[set[str]] = None
+    if allowed_properties:
+        allowed = {str(prop) for prop in allowed_properties}
+
+    compiled: List[Pattern] = []
+    raw_patterns = pack.get("patterns") if isinstance(pack, Mapping) else None
+    if isinstance(raw_patterns, Sequence):
+        for spec in raw_patterns:
+            if not isinstance(spec, Mapping):
+                continue
+            normalized = _normalize_pattern_spec(spec)
+            if not normalized:
+                continue
+            property_id = normalized["property_id"]
+            if allowed is not None and property_id not in allowed:
+                continue
+            tags = tuple(normalized["tags"] or [])
+            if tags and target_tags and not Pattern(property_id, tuple(), tags, tuple()).matches_tags(target_tags):
+                continue
+            flags = default_flags
+            if "flags" in spec:
+                custom_flags = 0
+                for item in _ensure_sequence(spec.get("flags")):
+                    if isinstance(item, str) and item.upper() in _FLAG_ALIASES:
+                        custom_flags |= _FLAG_ALIASES[item.upper()]
+                    elif isinstance(item, int):
+                        custom_flags |= int(item)
+                if custom_flags:
+                    flags = custom_flags
+            regexes = tuple(_compile_regex(pattern, flags) for pattern in normalized["regex"])
+            normals = tuple(normalized["normalizers"] or default_norms)
+            collect_many = bool(normalized["collect_many"] or default_collect_many)
+            compiled.append(
+                Pattern(
+                    property_id=property_id,
+                    regexes=regexes,
+                    tags=tags,
+                    normalizers=normals,
+                    collect_many=collect_many,
+                    priority=int(normalized["priority"]),
+                )
+            )
+    compiled.sort(key=lambda pat: pat.priority)
+    return tuple(compiled)
+
+
+def _cache_key(
+    pack: Mapping[str, Any],
+    allowed_properties: Optional[Sequence[str]],
+    target_tags: Optional[Sequence[str]],
+) -> Tuple[int, Tuple[str, ...], Tuple[str, ...]]:
+    allowed_key: Tuple[str, ...] = tuple(sorted(str(prop) for prop in allowed_properties)) if allowed_properties else ()
+    tags_key: Tuple[str, ...] = tuple(sorted(str(tag) for tag in target_tags)) if target_tags else ()
+    return (id(pack), allowed_key, tags_key)
+
+
+_COMPILED_CACHE: MutableMapping[Tuple[int, Tuple[str, ...], Tuple[str, ...]], Tuple[Pattern, ...]] = {}
+
+
+def _extract_value(match: re.Match[str]) -> Optional[str]:
+    if "value" in match.groupdict():
+        value = match.group("value")
+        if value:
+            return value
+    groups = match.groups()
+    for group in groups:
+        if group:
+            return group
+    return match.group(0) if match.group(0) else None
+
+
+Normalizer = Callable[[Any], Any]
+
+
+def _apply_map_enum(value: Any, mapping: Mapping[str, Any]) -> Any:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    lower = text.lower()
+    for key, mapped in mapping.items():
+        if not isinstance(key, str):
+            continue
+        if lower == key.lower():
+            return mapped
+    return mapping.get(text, text)
+
+
+def _normalize_bool(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"si", "sì", "yes", "true", "1"}:
+        return True
+    if text in {"no", "false", "0"}:
+        return False
+    return value
+
+
+def _to_number(value: Any) -> Any:
+    if isinstance(value, (int, float)):
+        return value
+    text = str(value).strip()
+    if not text:
+        return value
+    cleaned = text.replace("%", "").replace("\u202f", " ").replace("\xa0", " ")
+    cleaned = cleaned.replace(",", ".")
+    try:
+        number = float(cleaned)
+    except ValueError:
+        return value
+    if abs(number - round(number)) < 1e-6:
+        return int(round(number))
+    return number
+
+
+def _to_mm(value: Any, match: Optional[re.Match[str]]) -> Any:
+    number = _to_number(value)
+    if isinstance(number, str):
+        return number
+    if match is None:
+        return number
+    unit = match.groupdict().get("unit")
+    if not unit:
+        return number
+    unit = unit.lower()
+    if unit in {"mm", "millimetri"}:
+        return number
+    if unit in {"cm", "centimetri"}:
+        return float(number) * 10
+    if unit in {"m", "metri"}:
+        return float(number) * 1000
+    return number
+
+
+def _normalize_spaces(value: Any) -> Any:
+    text = str(value)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _normalize_lower(value: Any) -> Any:
+    return str(value).strip().lower()
+
+
+def _normalize_upper(value: Any) -> Any:
+    return str(value).strip().upper()
+
+
+def _normalize_ei(value: Any) -> Any:
+    text = str(value).upper()
+    digits = re.findall(r"\d+", text)
+    suffix = digits[0] if digits else ""
+    return f"EI {suffix}".strip()
+
+
+def _normalize_fire_reaction(value: Any) -> Any:
+    text = str(value).upper().replace(" ", "")
+    text = text.replace("S", "S").replace("D", "D")
+    return text
+
+
+def _normalize_pei(value: Any) -> Any:
+    text = str(value).upper().replace(" ", "")
+    if not text.startswith("PEI"):
+        text = "PEI" + text
+    return text
+
+
+def _normalize_slip_class(value: Any) -> Any:
+    text = str(value).upper().replace(" ", "")
+    return text
+
+
+def _normalize_format(value: Any, match: Optional[re.Match[str]]) -> Any:
+    text = _normalize_spaces(value)
+    unit = match.groupdict().get("unit") if match else None
+    unit = unit.lower() if isinstance(unit, str) else None
+    text = text.replace("×", "x")
+    if unit:
+        return f"{text} {unit}"
+    return text
+
+
+_BUILTIN_NORMALIZERS: Mapping[str, Callable[[Any, Optional[re.Match[str]]], Any]] = {
+    "strip": lambda value, match: str(value).strip() if value is not None else value,
+    "collapse_spaces": lambda value, match: _normalize_spaces(value) if value is not None else value,
+    "lower": lambda value, match: _normalize_lower(value) if value is not None else value,
+    "upper": lambda value, match: _normalize_upper(value) if value is not None else value,
+    "to_number": lambda value, match: _to_number(value),
+    "to_mm": lambda value, match: _to_mm(value, match),
+    "to_bool_strict": lambda value, match: _normalize_bool(value),
+    "normalize_ei": lambda value, match: _normalize_ei(value),
+    "normalize_fire_reaction": lambda value, match: _normalize_fire_reaction(value),
+    "normalize_pei": lambda value, match: _normalize_pei(value),
+    "normalize_slip_class": lambda value, match: _normalize_slip_class(value),
+    "normalize_format": lambda value, match: _normalize_format(value, match),
+}
+
+
+def _apply_normalizers(
+    value: Any,
+    normalizers: Sequence[str],
+    pack_normalizers: Mapping[str, Any],
+    match: Optional[re.Match[str]],
+    property_id: str,
+) -> Any:
+    current = value
+    for name in normalizers:
+        if current is None:
+            break
+        normalizer = name.strip()
+        if not normalizer:
+            continue
+        if normalizer.startswith("map_enum:"):
+            key = normalizer.split(":", 1)[1].strip()
+            mapping = pack_normalizers.get(key)
+            if isinstance(mapping, Mapping):
+                current = _apply_map_enum(current, mapping)
+            continue
+        func = _BUILTIN_NORMALIZERS.get(normalizer)
+        if func is not None:
+            current = func(current, match)
+            continue
+        mapping = pack_normalizers.get(normalizer)
+        if isinstance(mapping, Mapping):
+            current = _apply_map_enum(current, mapping)
+    return current
+
+
+def _iter_matches(text: str, pattern: Pattern) -> Iterable[Tuple[re.Match[str], Any]]:
+    for regex in pattern.regexes:
+        for match in regex.finditer(text):
+            value = _extract_value(match)
+            if value is None:
+                continue
+            yield match, value
+
+
+def extract_properties(
+    text: str,
+    pack: Mapping[str, Any],
+    *,
+    allowed_properties: Optional[Sequence[str]] = None,
+    target_tags: Optional[Sequence[str]] = None,
+    collect_many: bool = False,
+) -> Dict[str, Any]:
+    """Extract property values from *text* using the provided *pack*."""
+
+    cache_key = _cache_key(pack, allowed_properties, target_tags)
+    compiled = _COMPILED_CACHE.get(cache_key)
+    if compiled is None:
+        compiled = _compile_patterns(pack, allowed_properties, target_tags)
+        _COMPILED_CACHE[cache_key] = compiled
+
+    results: Dict[str, Any] = {}
+    pack_normalizers = pack.get("normalizers", {}) if isinstance(pack, Mapping) else {}
+    target_tags_tuple = tuple(target_tags) if target_tags else None
+    for pattern in compiled:
+        if target_tags_tuple and not pattern.matches_tags(target_tags_tuple):
+            continue
+        collected: List[Any] = []
+        for match, raw_value in _iter_matches(text, pattern):
+            value = _apply_normalizers(raw_value, pattern.normalizers, pack_normalizers, match, pattern.property_id)
+            if value is None or value == "":
+                continue
+            if isinstance(value, str):
+                value = value.strip()
+                if not value:
+                    continue
+            collected.append(value)
+        if not collected:
+            continue
+        if collect_many or pattern.collect_many:
+            existing = results.setdefault(pattern.property_id, [])
+            for item in collected:
+                if item not in existing:
+                    existing.append(item)
+        else:
+            results.setdefault(pattern.property_id, collected[0])
+    return results
+
+
+def dry_run(
+    samples: Iterable[Any],
+    pack: Mapping[str, Any],
+    *,
+    allowed_properties: Optional[Sequence[str]] = None,
+    target_tags: Optional[Sequence[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Run the extractor on *samples* returning the collected properties."""
+
+    outputs: List[Dict[str, Any]] = []
+    for sample in samples:
+        if isinstance(sample, Mapping):
+            text = str(sample.get("text", ""))
+        else:
+            text = str(sample)
+        outputs.append(
+            extract_properties(
+                text,
+                pack,
+                allowed_properties=allowed_properties,
+                target_tags=target_tags,
+                collect_many=True,
+            )
+        )
+    return outputs
+
+
+def validate_extractors_pack(pack: Mapping[str, Any]) -> List[str]:
+    """Validate the pack returning a list of problems (empty if valid)."""
+
+    errors: List[str] = []
+    patterns = pack.get("patterns") if isinstance(pack, Mapping) else None
+    if not isinstance(patterns, Sequence) or not patterns:
+        return ["extractors pack must define a non-empty 'patterns' list"]
+    defaults = pack.get("defaults") if isinstance(pack, Mapping) else None
+    flags = _DEFAULT_FLAGS
+    if isinstance(defaults, Mapping):
+        raw_flags = _ensure_sequence(defaults.get("flags"))
+        for item in raw_flags:
+            if isinstance(item, str) and item.upper() in _FLAG_ALIASES:
+                flags |= _FLAG_ALIASES[item.upper()]
+            elif isinstance(item, int):
+                flags |= int(item)
+    for idx, raw_spec in enumerate(patterns, start=1):
+        if not isinstance(raw_spec, Mapping):
+            errors.append(f"pattern {idx}: expected a mapping, got {type(raw_spec).__name__}")
+            continue
+        normalized = _normalize_pattern_spec(raw_spec)
+        if not normalized:
+            errors.append(f"pattern {idx}: missing property_id or regex definitions")
+            continue
+        custom_flags = flags
+        if "flags" in raw_spec:
+            custom_flags = 0
+            for item in _ensure_sequence(raw_spec.get("flags")):
+                if isinstance(item, str) and item.upper() in _FLAG_ALIASES:
+                    custom_flags |= _FLAG_ALIASES[item.upper()]
+                elif isinstance(item, int):
+                    custom_flags |= int(item)
+            if not custom_flags:
+                custom_flags = flags
+        for pattern in normalized["regex"]:
+            try:
+                _compile_regex(pattern, custom_flags)
+            except re.error as exc:
+                errors.append(
+                    f"pattern {idx} ({normalized['property_id']}): invalid regex '{pattern}': {exc}"
+                )
+    return errors


### PR DESCRIPTION
## Summary
- add a regex-based `robimb.extraction.legacy` module that compiles extractor packs and exposes extraction helpers
- recreate the default `pack/current` bundle with a registry copy and fallback regex patterns derived from `data/properties`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc1f0ab7e88322929ac1edbc89ece4