### PR TITLE
Implement property extraction orchestrator with fallback

### DIFF
--- a/src/robimb/extraction/fuse.py
+++ b/src/robimb/extraction/fuse.py
@@ -1,0 +1,110 @@
+"""Candidate fusion policies for property extraction."""
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Sequence, TypedDict
+
+__all__ = ["FusePolicy", "Candidate", "Fuser"]
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FusePolicy(str, Enum):
+    """Supported fusion strategies."""
+
+    VALIDATE_THEN_MAX_CONF = "validate_then_max_conf"
+
+
+class Candidate(TypedDict, total=False):
+    """Representation of a candidate produced by an extractor."""
+
+    value: Any
+    source: Optional[str]
+    raw: Optional[str]
+    span: Optional[tuple[int, int] | list[int]]
+    confidence: float
+    unit: Optional[str]
+    errors: List[str]
+
+
+class Fuser:
+    """Fuse property candidates according to a configurable policy."""
+
+    def __init__(
+        self,
+        policy: FusePolicy = FusePolicy.VALIDATE_THEN_MAX_CONF,
+        *,
+        source_priority: Sequence[str] | None = None,
+    ) -> None:
+        self._policy = policy
+        self._source_priority = list(source_priority or ("parser", "matcher", "qa_llm", "fuse", "manual"))
+        self._priority_index: Dict[str, int] = {name: idx for idx, name in enumerate(self._source_priority)}
+
+    def fuse(
+        self,
+        candidates: List[Candidate],
+        validator: Callable[[Candidate], bool | tuple[bool, List[str]]],
+    ) -> Candidate:
+        """Fuse ``candidates`` using the configured ``policy``.
+
+        Parameters
+        ----------
+        candidates:
+            Ordered list of candidates proposed by upstream extractors.
+        validator:
+            Callable that evaluates candidate compliance. The callable may
+            return a boolean or a ``(bool, list[str])`` tuple describing the
+            validation outcome and associated error messages.
+
+        Returns
+        -------
+        Candidate
+            The selected candidate or an empty placeholder if none were valid.
+        """
+
+        if self._policy is not FusePolicy.VALIDATE_THEN_MAX_CONF:
+            raise NotImplementedError(f"Policy {self._policy!s} is not implemented")
+
+        valid_candidates: List[Candidate] = []
+
+        for candidate in candidates:
+            result = validator(candidate)
+            if isinstance(result, tuple):
+                is_valid, messages = result
+            else:
+                is_valid, messages = bool(result), []
+            if not is_valid:
+                errors = list(candidate.get("errors", []))
+                if messages:
+                    errors.extend(messages)
+                else:
+                    errors.append("validation_failed")
+                candidate["errors"] = errors
+                LOGGER.debug("candidate_rejected", extra={"candidate": candidate})
+                continue
+            candidate["errors"] = list(candidate.get("errors", []))
+            valid_candidates.append(candidate)
+
+        if not valid_candidates:
+            return Candidate(
+                value=None,
+                source=None,
+                raw=None,
+                span=None,
+                confidence=0.0,
+                unit=None,
+                errors=["no_valid_candidate"],
+            )
+
+        def _sort_key(item: Candidate) -> tuple[float, int, int]:
+            confidence = float(item.get("confidence") or 0.0)
+            source = item.get("source")
+            priority = self._priority_index.get(source or "", len(self._priority_index))
+            original_index = candidates.index(item)
+            return (-confidence, priority, original_index)
+
+        winner = min(valid_candidates, key=_sort_key)
+        LOGGER.debug("candidate_selected", extra={"candidate": winner})
+        return winner

--- a/src/robimb/extraction/matchers/__init__.py
+++ b/src/robimb/extraction/matchers/__init__.py
@@ -1,0 +1,3 @@
+"""Lexical matchers for property extraction."""
+
+__all__ = []

--- a/src/robimb/extraction/matchers/brands.py
+++ b/src/robimb/extraction/matchers/brands.py
@@ -1,0 +1,26 @@
+"""Minimal lexical matcher for brand mentions."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+__all__ = ["BrandMatcher"]
+
+
+class BrandMatcher:
+    """Naïve case-insensitive matcher for known brand names."""
+
+    def __init__(self, lexicon: Optional[set[str]] = None) -> None:
+        self._lexicon = {item.lower(): item for item in (lexicon or set())}
+
+    def find(self, text: str) -> list[tuple[str, tuple[int, int], float]]:
+        """Return matches as ``(brand, span, score)`` tuples."""
+
+        lowered = text.lower()
+        results: List[tuple[str, tuple[int, int], float]] = []
+        for key, surface in self._lexicon.items():
+            start = lowered.find(key)
+            if start == -1:
+                continue
+            end = start + len(key)
+            results.append((surface, (start, end), 1.0))
+        return results

--- a/src/robimb/extraction/orchestrator.py
+++ b/src/robimb/extraction/orchestrator.py
@@ -1,0 +1,360 @@
+"""Orchestrates multi-strategy property extraction with cascading fallbacks."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from pydantic import BaseModel, Field
+
+from .fuse import Candidate, Fuser
+from .matchers.brands import BrandMatcher
+from .parsers import dimensions, numbers
+from .qa_llm import QALLM
+from .schema_registry import PropertySpec, load_category_schema
+from .validators import validate_properties
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = ["Orchestrator", "OrchestratorConfig"]
+
+
+class OrchestratorConfig(BaseModel):
+    """Configuration for the property extraction orchestrator."""
+
+    source_priority: List[str] = Field(default_factory=lambda: ["parser", "matcher", "qa_llm"])
+    enable_matcher: bool = True
+    enable_llm: bool = True
+    registry_path: str = "data/properties/registry.json"
+
+
+class Orchestrator:
+    """Coordinate deterministic parsers, matchers and LLM fallbacks."""
+
+    def __init__(self, fuse: Fuser, llm: Optional[QALLM], cfg: OrchestratorConfig) -> None:
+        self._fuse = fuse
+        self._llm = llm if cfg.enable_llm else None
+        self._cfg = cfg
+        self._brand_matcher = BrandMatcher()
+
+    def extract_document(self, doc: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract properties for a single document."""
+
+        text_id = doc.get("text_id")
+        category_id = doc.get("categoria")
+        text = doc.get("text", "") or ""
+
+        if not category_id:
+            raise ValueError("Input document is missing 'categoria'")
+
+        category, schema = load_category_schema(category_id, registry_path=self._cfg.registry_path)
+        property_specs = {prop.id: prop for prop in category.properties}
+        schema_properties = self._resolve_schema_properties(schema)
+
+        properties_payload: Dict[str, Dict[str, Any]] = {}
+        for prop_id, prop_schema in schema_properties.items():
+            spec = property_specs.get(prop_id)
+            result = self._extract_property(text, category_id, prop_id, prop_schema, spec)
+            properties_payload[prop_id] = result
+
+        validation_input = {
+            prop_id: {
+                "value": payload["value"],
+                "unit": payload.get("unit"),
+                "source": payload["source"],
+                "raw": payload.get("raw"),
+                "span": payload.get("span"),
+                "confidence": payload.get("confidence"),
+            }
+            for prop_id, payload in properties_payload.items()
+            if payload.get("source")
+        }
+
+        validation = validate_properties(
+            category_id,
+            validation_input,
+            registry_path=self._cfg.registry_path,
+        )
+        for issue in validation.errors:
+            result = properties_payload.setdefault(
+                issue.property_id,
+                {
+                    "value": None,
+                    "source": None,
+                    "unit": None,
+                    "raw": None,
+                    "span": None,
+                    "confidence": 0.0,
+                    "errors": [],
+                },
+            )
+            result.setdefault("errors", []).append(issue.message)
+
+        confidence_values = [
+            float(payload.get("confidence") or 0.0)
+            for payload in properties_payload.values()
+            if payload.get("value") is not None
+        ]
+        confidence_overall = sum(confidence_values) / len(confidence_values) if confidence_values else 0.0
+
+        LOGGER.info(
+            "document_processed",
+            extra={
+                "text_id": text_id,
+                "category": category_id,
+                "confidence_overall": confidence_overall,
+                "validation_status": "ok" if validation.ok else "failed",
+            },
+        )
+
+        return {
+            "text_id": text_id,
+            "categoria": category_id,
+            "properties": properties_payload,
+            "validation": {
+                "status": "ok" if validation.ok else "failed",
+                "errors": [
+                    {
+                        "property_id": issue.property_id,
+                        "code": issue.code,
+                        "message": issue.message,
+                    }
+                    for issue in validation.errors
+                ],
+            },
+            "confidence_overall": confidence_overall,
+        }
+
+    def _extract_property(
+        self,
+        text: str,
+        cat: str,
+        prop: str,
+        prop_schema: Dict[str, Any],
+        prop_spec: Optional[PropertySpec] = None,
+    ) -> Dict[str, Any]:
+        allowed_sources = self._determine_sources(prop_spec)
+        candidates: List[Candidate] = []
+
+        if "parser" in allowed_sources:
+            candidates.extend(self._parser_candidates(prop, prop_spec, text))
+
+        if self._cfg.enable_matcher and "matcher" in allowed_sources:
+            candidates.extend(self._matcher_candidates(prop, text))
+
+        if self._llm and "qa_llm" in allowed_sources:
+            llm_candidate = self._llm_candidate(prop, text, prop_schema)
+            if llm_candidate:
+                candidates.append(llm_candidate)
+
+        validator = self._build_validator(prop_spec)
+        fused = self._fuse.fuse(candidates, validator)
+
+        span = self._normalize_span(fused.get("span"))
+        unit = fused.get("unit")
+        errors = list(fused.get("errors", []))
+        confidence = float(fused.get("confidence") or 0.0)
+        source = fused.get("source")
+        value = fused.get("value")
+        raw = fused.get("raw")
+
+        result: Dict[str, Any] = {
+            "value": value,
+            "source": source,
+            "raw": raw,
+            "span": span,
+            "confidence": confidence,
+            "unit": unit,
+            "errors": errors,
+        }
+
+        LOGGER.info(
+            "property_fused",
+            extra={
+                "category": cat,
+                "property": prop,
+                "candidates": candidates,
+                "selected": result,
+            },
+        )
+
+        return result
+
+    def _determine_sources(self, spec: Optional[PropertySpec]) -> Sequence[str]:
+        if spec and spec.sources:
+            return [source for source in spec.sources if source in self._cfg.source_priority]
+        return list(self._cfg.source_priority)
+
+    def _normalize_span(self, span: Any) -> Optional[List[int]]:
+        if span is None:
+            return None
+        if isinstance(span, list):
+            return [int(span[0]), int(span[1])]
+        if isinstance(span, tuple):
+            return [int(span[0]), int(span[1])]
+        raise TypeError(f"Unsupported span type: {type(span)!r}")
+
+    def _parser_candidates(
+        self, prop_id: str, spec: Optional[PropertySpec], text: str
+    ) -> Iterable[Candidate]:
+        results: List[Candidate] = []
+        lowered = prop_id.lower()
+
+        if any(token in lowered for token in ("dimension", "formato")):
+            for match in dimensions.parse_dimensions(text):
+                values = match.values_mm
+                if "larghezza" in lowered or "width" in lowered:
+                    selected = values[0] if values else None
+                elif "altezza" in lowered or "height" in lowered:
+                    selected = values[1] if len(values) > 1 else (values[0] if values else None)
+                elif "profond" in lowered or "depth" in lowered:
+                    selected = values[2] if len(values) > 2 else None
+                else:
+                    keys = ["width_mm", "height_mm", "depth_mm"]
+                    selected = {key: values[idx] for idx, key in enumerate(keys) if idx < len(values)}
+                if selected is None:
+                    continue
+                results.append(
+                    Candidate(
+                        value=selected,
+                        source="parser",
+                        raw=match.raw,
+                        span=match.span,
+                        confidence=0.90,
+                        unit="mm" if isinstance(selected, (int, float)) else None,
+                        errors=[],
+                    )
+                )
+
+        elif any(token in lowered for token in ("spessore", "spessori")):
+            for match in numbers.extract_numbers(text):
+                results.append(
+                    Candidate(
+                        value=match.value,
+                        source="parser",
+                        raw=match.raw,
+                        span=(match.start, match.end),
+                        confidence=0.90,
+                        unit="mm",
+                        errors=[],
+                    )
+                )
+
+        elif "db" in lowered or "decibel" in lowered:
+            for match in numbers.extract_numbers(text):
+                window = text[match.end : min(len(text), match.end + 5)].lower()
+                previous = text[max(0, match.start - 5) : match.start].lower()
+                if "db" not in window and "db" not in previous:
+                    continue
+                results.append(
+                    Candidate(
+                        value=match.value,
+                        source="parser",
+                        raw=match.raw,
+                        span=(match.start, match.end),
+                        confidence=0.90,
+                        unit="db",
+                        errors=[],
+                    )
+                )
+
+        return results
+
+    def _matcher_candidates(self, prop_id: str, text: str) -> Iterable[Candidate]:
+        if prop_id.lower() != "marchio":
+            return []
+        results: List[Candidate] = []
+        for brand, span, score in self._brand_matcher.find(text):
+            results.append(
+                Candidate(
+                    value=brand,
+                    source="matcher",
+                    raw=text[span[0] : span[1]],
+                    span=span,
+                    confidence=0.70 * float(score),
+                    unit=None,
+                    errors=[],
+                )
+            )
+        return results
+
+    def _llm_candidate(self, prop_id: str, text: str, prop_schema: Dict[str, Any]) -> Optional[Candidate]:
+        value_schema = self._extract_value_schema(prop_schema)
+        llm_schema = {
+            "type": "object",
+            "properties": {
+                "value": value_schema,
+                "confidence": {
+                    "type": ["number", "null"],
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                },
+            },
+            "required": ["value"],
+            "additionalProperties": False,
+        }
+        question = f"Estrai il valore della proprietà '{prop_id}'."
+        try:
+            response = self._llm.ask(text, question, llm_schema)
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.warning("llm_error", extra={"property": prop_id, "error": str(exc)})
+            return None
+        value = response.get("value")
+        confidence = response.get("confidence")
+        confidence_value = float(confidence) if isinstance(confidence, (int, float)) else 0.60
+        span = response.get("span")
+        candidate: Candidate = Candidate(
+            value=value,
+            source="qa_llm",
+            raw=response.get("raw"),
+            span=span if isinstance(span, (list, tuple)) else None,
+            confidence=confidence_value,
+            unit=response.get("unit"),
+            errors=list(response.get("errors", [])) if isinstance(response.get("errors"), list) else [],
+        )
+        return candidate
+
+    def _build_validator(self, spec: Optional[PropertySpec]):
+        def _validator(candidate: Candidate) -> tuple[bool, List[str]]:
+            errors: List[str] = []
+            if spec is None:
+                return True, errors
+            value = candidate.get("value")
+            if value is None:
+                errors.append("value_missing")
+                return False, errors
+            expected = (spec.type or "string").lower()
+            if expected in {"number", "float"} and not isinstance(value, (int, float)):
+                errors.append("expected_number")
+            elif expected == "integer" and not isinstance(value, int):
+                errors.append("expected_integer")
+            elif expected == "boolean" and not isinstance(value, bool):
+                errors.append("expected_boolean")
+            elif expected in {"array", "list"} and not isinstance(value, (list, tuple)):
+                errors.append("expected_array")
+            elif expected in {"object", "dict"} and not isinstance(value, dict):
+                errors.append("expected_object")
+            elif expected in {"string", "text"} and not isinstance(value, str):
+                errors.append("expected_string")
+
+            if spec.enum and value not in spec.enum:
+                errors.append("enum_mismatch")
+
+            if spec.unit and candidate.get("unit") not in {spec.unit, None}:
+                errors.append("unit_mismatch")
+
+            return (not errors), errors
+
+        return _validator
+
+    def _resolve_schema_properties(self, schema: Dict[str, Any]) -> Dict[str, Any]:
+        props = schema.get("properties", {})
+        return props.get("properties", {}).get("properties", {})
+
+    def _extract_value_schema(self, prop_schema: Dict[str, Any]) -> Dict[str, Any]:
+        if "properties" in prop_schema and "value" in prop_schema["properties"]:
+            return prop_schema["properties"]["value"]
+        all_of = prop_schema.get("allOf", [])
+        for entry in all_of:
+            if isinstance(entry, dict) and "properties" in entry and "value" in entry["properties"]:
+                return entry["properties"]["value"]
+        return {"type": ["string", "number", "boolean", "null", "object", "array"]}

--- a/src/robimb/extraction/qa_llm.py
+++ b/src/robimb/extraction/qa_llm.py
@@ -1,0 +1,106 @@
+"""Adapters for question-answering large language models."""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional, Protocol
+
+from pydantic import BaseModel, Field
+
+__all__ = ["QALLM", "QALLMConfig", "HttpLLM", "MockLLM", "build_prompt"]
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class QALLMConfig(BaseModel):
+    """Configuration for QA-oriented LLM clients."""
+
+    endpoint: Optional[str] = Field(default=None, description="HTTP endpoint accepting JSON payloads")
+    model: Optional[str] = Field(default=None, description="Remote model identifier")
+    timeout: float = Field(default=30.0, ge=1.0, description="Timeout for each request in seconds")
+    max_retries: int = Field(default=2, ge=0, description="Number of retry attempts on failure")
+
+
+class QALLM(Protocol):
+    """Protocol implemented by QA-capable LLM adapters."""
+
+    def ask(self, text: str, question: str, json_schema: Dict[str, Any]) -> Dict[str, Any]:
+        """Answer ``question`` grounding only on ``text``.
+
+        Implementations must return a JSON-serialisable dictionary containing at
+        least the ``value`` key. Additional metadata such as ``confidence`` may
+        be provided.
+        """
+
+
+def build_prompt(text: str, question: str, schema: Dict[str, Any]) -> str:
+    """Construct a deterministic prompt instructing the model to output JSON."""
+
+    schema_json = json.dumps(schema, ensure_ascii=False, indent=2)
+    prompt_lines = [
+        "Sei un assistente specializzato nell'estrazione di proprietà da descrizioni tecniche.",
+        "Lavora SOLO sul testo fornito. Se l'informazione non è presente, restituisci null.",
+        "Copia verbatim i valori testuali, senza aggiungere spiegazioni.",
+        "Rispondi esclusivamente con JSON valido conforme allo schema fornito.",
+        "Testo da analizzare:",
+        text.strip() or "<vuoto>",
+        "Domanda:",
+        question,
+        "Schema JSON della risposta:",
+        schema_json,
+    ]
+    return "\n".join(prompt_lines)
+
+
+class HttpLLM(QALLM):
+    """HTTP client calling an external LLM endpoint."""
+
+    def __init__(self, config: QALLMConfig):
+        if not config.endpoint:
+            raise ValueError("HttpLLM requires a non-empty endpoint")
+        self._config = config
+
+    def ask(self, text: str, question: str, json_schema: Dict[str, Any]) -> Dict[str, Any]:
+        payload = {
+            "model": self._config.model,
+            "prompt": build_prompt(text, question, json_schema),
+            "schema": json_schema,
+        }
+        attempts = self._config.max_retries + 1
+        for attempt in range(attempts):
+            try:
+                body = json.dumps(payload).encode("utf-8")
+                request = urllib.request.Request(
+                    self._config.endpoint,
+                    data=body,
+                    method="POST",
+                    headers={"Content-Type": "application/json", "Accept": "application/json"},
+                )
+                with urllib.request.urlopen(request, timeout=self._config.timeout) as response:
+                    charset = response.headers.get_content_charset("utf-8")
+                    data = response.read().decode(charset)
+                parsed = json.loads(data)
+                if not isinstance(parsed, dict):
+                    raise ValueError("LLM response must be a JSON object")
+                return parsed
+            except (urllib.error.URLError, json.JSONDecodeError, ValueError) as exc:
+                LOGGER.warning(
+                    "llm_call_failed",
+                    extra={"attempt": attempt + 1, "max_attempts": attempts, "error": str(exc)},
+                )
+                if attempt + 1 >= attempts:
+                    raise
+                delay = 2 ** attempt
+                time.sleep(delay)
+        raise RuntimeError("LLM call failed after retries")
+
+
+class MockLLM(QALLM):
+    """Fallback implementation used when no endpoint is configured."""
+
+    def ask(self, text: str, question: str, json_schema: Dict[str, Any]) -> Dict[str, Any]:
+        return {"value": None, "confidence": 0.0}

--- a/src/robimb/extraction/schema_registry.py
+++ b/src/robimb/extraction/schema_registry.py
@@ -12,6 +12,7 @@ __all__ = [
     "CategorySchema",
     "SchemaRegistry",
     "load_registry",
+    "load_category_schema",
 ]
 
 
@@ -100,3 +101,39 @@ def load_registry(registry_path: Path | str) -> SchemaRegistry:
     """Load and cache the registry located at ``registry_path``."""
 
     return SchemaRegistry(Path(registry_path))
+
+
+def load_category_schema(
+    category_id: str,
+    *,
+    registry_path: Path | str = Path("data/properties/registry.json"),
+) -> tuple[CategorySchema, Dict[str, Any]]:
+    """Return the :class:`CategorySchema` metadata and JSON schema body.
+
+    Parameters
+    ----------
+    category_id:
+        Identifier of the category to load.
+    registry_path:
+        Path to the registry JSON file. Defaults to the project-wide registry.
+
+    Returns
+    -------
+    tuple[CategorySchema, Dict[str, Any]]
+        The dataclass describing the category together with the parsed JSON
+        schema document.
+
+    Raises
+    ------
+    ValueError
+        If the requested category is not present in the registry or the schema
+        file cannot be read.
+    """
+
+    registry = load_registry(Path(registry_path))
+    category = registry.get(category_id)
+    if category is None:
+        raise ValueError(f"Categoria '{category_id}' non presente nel registry")
+    schema_path = category.schema_path
+    payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    return category, payload

--- a/tests/test_extract_cli.py
+++ b/tests/test_extract_cli.py
@@ -1,0 +1,128 @@
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from robimb.cli.extract import app
+
+
+def _prepare_registry(tmp_path: Path) -> Path:
+    category_id = "categoria_cli"
+    schema_path = tmp_path / "schema.json"
+    schema_payload = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "Schema CLI",
+        "type": "object",
+        "properties": {
+            "category": {"const": category_id},
+            "properties": {
+                "type": "object",
+                "properties": {
+                    "dimensioni": {
+                        "properties": {
+                            "value": {
+                                "type": "object",
+                                "properties": {
+                                    "width_mm": {"type": "number"},
+                                    "height_mm": {"type": "number"},
+                                }
+                            }
+                        }
+                    },
+                    "isolamento_db": {
+                        "properties": {
+                            "value": {"type": "number"}
+                        }
+                    },
+                },
+            },
+        },
+    }
+    schema_path.write_text(json.dumps(schema_payload, ensure_ascii=False), encoding="utf-8")
+
+    registry_path = tmp_path / "registry.json"
+    registry_payload = {
+        "categories": [
+            {
+                "id": category_id,
+                "name": "Categoria CLI",
+                "schema": str(schema_path),
+                "required": [],
+                "properties": [
+                    {"id": "dimensioni", "title": "Dimensioni", "type": "object", "sources": ["parser"]},
+                    {
+                        "id": "isolamento_db",
+                        "title": "Isolamento acustico",
+                        "type": "number",
+                        "unit": "db",
+                        "sources": ["parser", "qa_llm"],
+                    },
+                ],
+            }
+        ]
+    }
+    registry_path.write_text(json.dumps(registry_payload, ensure_ascii=False), encoding="utf-8")
+    return registry_path
+
+
+def test_extract_cli_end_to_end(tmp_path: Path) -> None:
+    registry_path = _prepare_registry(tmp_path)
+    pack_dir = tmp_path / "pack"
+    pack_dir.mkdir()
+
+    input_path = tmp_path / "input.jsonl"
+    output_path = tmp_path / "output.jsonl"
+
+    docs = [
+        {
+            "text_id": "doc-1",
+            "categoria": "categoria_cli",
+            "text": "Pannello con dimensioni 0,90x2,10 m e isolamento ≥ 50 dB.",
+        },
+        {"text_id": "doc-2", "categoria": "categoria_cli", "text": "Nessuna informazione."},
+    ]
+    with input_path.open("w", encoding="utf-8") as fh:
+        for doc in docs:
+            fh.write(json.dumps(doc, ensure_ascii=False) + "\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "properties",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--pack",
+            str(pack_dir),
+            "--schema",
+            str(registry_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "completed" in result.stdout
+
+    lines = [
+        json.loads(line)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    assert len(lines) == 2
+
+    first = lines[0]
+    dim = first["properties"]["dimensioni"]
+    iso = first["properties"]["isolamento_db"]
+    assert dim["value"]["width_mm"] == pytest.approx(900.0, rel=1e-3)
+    assert dim["value"]["height_mm"] == pytest.approx(2100.0, rel=1e-3)
+    assert iso["value"] == pytest.approx(50.0, rel=1e-3)
+    assert first["validation"]["status"] == "ok"
+    assert first["confidence_overall"] > 0.0
+
+    second = lines[1]
+    assert second["properties"]["dimensioni"]["value"] is None
+    assert second["properties"]["isolamento_db"]["value"] is None
+    assert second["confidence_overall"] == 0.0

--- a/tests/test_fuse_policy.py
+++ b/tests/test_fuse_policy.py
@@ -1,0 +1,53 @@
+from robimb.extraction.fuse import Candidate, Fuser, FusePolicy
+
+
+def _accept(candidate: Candidate):
+    return True, []
+
+
+def test_fuser_prefers_highest_confidence() -> None:
+    fuser = Fuser(policy=FusePolicy.VALIDATE_THEN_MAX_CONF)
+    candidates: list[Candidate] = [
+        {
+            "value": 42,
+            "source": "parser",
+            "raw": "42",
+            "span": (0, 2),
+            "confidence": 0.88,
+            "errors": [],
+        },
+        {
+            "value": 42,
+            "source": "qa_llm",
+            "raw": "42",
+            "span": (0, 2),
+            "confidence": 0.92,
+            "errors": [],
+        },
+    ]
+    winner = fuser.fuse(candidates, _accept)
+    assert winner["source"] == "qa_llm"
+
+
+def test_fuser_uses_source_priority_on_ties() -> None:
+    fuser = Fuser(policy=FusePolicy.VALIDATE_THEN_MAX_CONF)
+    candidates: list[Candidate] = [
+        {
+            "value": "A",
+            "source": "parser",
+            "raw": "A",
+            "span": (0, 1),
+            "confidence": 0.9,
+            "errors": [],
+        },
+        {
+            "value": "A",
+            "source": "qa_llm",
+            "raw": "A",
+            "span": (0, 1),
+            "confidence": 0.9,
+            "errors": [],
+        },
+    ]
+    winner = fuser.fuse(candidates, _accept)
+    assert winner["source"] == "parser"

--- a/tests/test_orchestrator_basic.py
+++ b/tests/test_orchestrator_basic.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from robimb.extraction.fuse import Fuser, FusePolicy
+from robimb.extraction.orchestrator import Orchestrator, OrchestratorConfig
+from robimb.extraction.qa_llm import MockLLM
+
+
+def _write_registry(tmp_path: Path) -> Path:
+    category_id = "categoria_test"
+    schema_path = tmp_path / "schema.json"
+    schema_payload = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "Schema test",
+        "type": "object",
+        "properties": {
+            "category": {"const": category_id},
+            "properties": {
+                "type": "object",
+                "properties": {
+                    "dimensioni": {
+                        "properties": {
+                            "value": {
+                                "type": "object",
+                                "properties": {
+                                    "width_mm": {"type": "number"},
+                                    "height_mm": {"type": "number"},
+                                },
+                                "required": ["width_mm", "height_mm"],
+                            }
+                        }
+                    }
+                },
+            },
+        },
+    }
+    schema_path.write_text(json.dumps(schema_payload, ensure_ascii=False), encoding="utf-8")
+
+    registry_path = tmp_path / "registry.json"
+    registry_payload = {
+        "categories": [
+            {
+                "id": category_id,
+                "name": "Categoria test",
+                "schema": str(schema_path),
+                "required": [],
+                "properties": [
+                    {
+                        "id": "dimensioni",
+                        "title": "Dimensioni",
+                        "type": "object",
+                        "sources": ["parser", "qa_llm"],
+                    }
+                ],
+            }
+        ]
+    }
+    registry_path.write_text(json.dumps(registry_payload, ensure_ascii=False), encoding="utf-8")
+    return registry_path
+
+
+def test_orchestrator_basic(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path)
+    cfg = OrchestratorConfig(registry_path=str(registry_path))
+    fuser = Fuser(policy=FusePolicy.VALIDATE_THEN_MAX_CONF, source_priority=cfg.source_priority)
+    orchestrator = Orchestrator(fuse=fuser, llm=MockLLM(), cfg=cfg)
+
+    doc = {
+        "text_id": "doc-1",
+        "categoria": "categoria_test",
+        "text": "Porta dimensioni 90x210 cm con finitura bianca.",
+    }
+
+    result = orchestrator.extract_document(doc)
+    properties = result["properties"]["dimensioni"]
+
+    assert properties["source"] == "parser"
+    assert properties["confidence"] >= 0.85
+    assert pytest.approx(properties["value"]["width_mm"], rel=1e-3) == 900.0
+    assert pytest.approx(properties["value"]["height_mm"], rel=1e-3) == 2100.0
+    assert result["validation"]["status"] == "ok"

--- a/tests/test_qa_llm_mock.py
+++ b/tests/test_qa_llm_mock.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+
+from robimb.extraction.fuse import Fuser, FusePolicy
+from robimb.extraction.orchestrator import Orchestrator, OrchestratorConfig
+from robimb.extraction.qa_llm import MockLLM
+
+
+def _registry_llm_only(tmp_path: Path) -> Path:
+    category_id = "cat_llm"
+    schema_path = tmp_path / "schema.json"
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "Schema QA",
+        "type": "object",
+        "properties": {
+            "category": {"const": category_id},
+            "properties": {
+                "type": "object",
+                "properties": {
+                    "descrizione": {
+                        "properties": {
+                            "value": {"type": ["string", "null"]}
+                        }
+                    }
+                },
+            },
+        },
+    }
+    schema_path.write_text(json.dumps(schema, ensure_ascii=False), encoding="utf-8")
+
+    registry_path = tmp_path / "registry.json"
+    registry = {
+        "categories": [
+            {
+                "id": category_id,
+                "name": "Categoria QA",
+                "schema": str(schema_path),
+                "required": [],
+                "properties": [
+                    {"id": "descrizione", "title": "Descrizione", "type": "string", "sources": ["qa_llm"]}
+                ],
+            }
+        ]
+    }
+    registry_path.write_text(json.dumps(registry, ensure_ascii=False), encoding="utf-8")
+    return registry_path
+
+
+def test_mock_llm_returns_null(tmp_path: Path) -> None:
+    registry_path = _registry_llm_only(tmp_path)
+    cfg = OrchestratorConfig(registry_path=str(registry_path))
+    orchestrator = Orchestrator(
+        fuse=Fuser(policy=FusePolicy.VALIDATE_THEN_MAX_CONF, source_priority=cfg.source_priority),
+        llm=MockLLM(),
+        cfg=cfg,
+    )
+
+    doc = {"text_id": "qa", "categoria": "cat_llm", "text": "Dato non presente."}
+    result = orchestrator.extract_document(doc)
+    prop = result["properties"]["descrizione"]
+
+    assert prop["value"] is None
+    assert prop["source"] is None
+    assert prop["confidence"] == 0.0
+    assert "no_valid_candidate" in prop["errors"]


### PR DESCRIPTION
## Summary
- add a fuse module, QA LLM adapter, and orchestrator to run parser → matcher → QA fallbacks
- wire the new orchestrator into the `robimb extract properties` command and expose configuration for the LLM client
- provide regression tests covering fusion policy, orchestrator behaviour, the CLI flow, and the mock LLM pathway

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc288a9b008322b2f41d0c439cf61f