### PR TITLE
Handle category aliases in orchestrator

### DIFF
--- a/tests/test_orchestrator_basic.py
+++ b/tests/test_orchestrator_basic.py
@@ -81,3 +81,24 @@ def test_orchestrator_basic(tmp_path: Path) -> None:
     assert pytest.approx(properties["value"]["width_mm"], rel=1e-3) == 900.0
     assert pytest.approx(properties["value"]["height_mm"], rel=1e-3) == 2100.0
     assert result["validation"]["status"] == "ok"
+
+
+def test_orchestrator_accepts_category_alias(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path)
+    cfg = OrchestratorConfig(registry_path=str(registry_path))
+    orchestrator = Orchestrator(
+        fuse=Fuser(policy=FusePolicy.VALIDATE_THEN_MAX_CONF, source_priority=cfg.source_priority),
+        llm=MockLLM(),
+        cfg=cfg,
+    )
+
+    doc = {
+        "id": 42,
+        "cat": "categoria_test",
+        "text": "Pannello in cartongesso 60x60 cm spessore 12 mm.",
+    }
+
+    result = orchestrator.extract_document(doc)
+
+    assert result["categoria"] == "categoria_test"
+    assert result["text_id"] == "42"


### PR DESCRIPTION
## Summary
- allow the orchestrator to resolve category identifiers from common alias fields
- add helper to derive text identifiers from alternate keys
- cover the new behaviour with a unit test for alias-based documents

## Testing
- pytest tests/test_orchestrator_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd7e2a9f8832296869ae84d721cb9