### PR TITLE
Fix width parsing for two-value dimensions

### DIFF
--- a/src/robimb/extraction/orchestrator.py
+++ b/src/robimb/extraction/orchestrator.py
@@ -347,11 +347,8 @@ class Orchestrator:
                     else:
                         selected = values[0]
                 elif "larghezza" in lowered or "width" in lowered:
-                    # For width: second value in 2D (WxD), first in 3D (WxHxD)
-                    if len(values) == 2:
-                        selected = values[1]
-                    else:
-                        selected = values[0]
+                    # For width: keep the first value regardless of 2D/3D formats
+                    selected = values[0] if values else None
                 elif "altezza" in lowered or "height" in lowered:
                     # For height: second value in 2D (WxH), third in 3D door format (WxHxD), or largest if door-like
                     if len(values) == 2:

--- a/tests/test_orchestrator_basic.py
+++ b/tests/test_orchestrator_basic.py
@@ -147,3 +147,31 @@ def test_parser_candidates_extract_length_value() -> None:
     assert candidate["unit"] == "mm"
     assert pytest.approx(candidate["value"], rel=1e-3) == 200.0
 
+
+def test_parser_candidates_preserve_width_and_height_values() -> None:
+    cfg = OrchestratorConfig(
+        source_priority=["parser"],
+        enable_matcher=False,
+        enable_llm=False,
+        registry_path="",
+    )
+    orchestrator = Orchestrator(
+        fuse=Fuser(policy=FusePolicy.VALIDATE_THEN_MAX_CONF, source_priority=cfg.source_priority),
+        llm=None,
+        cfg=cfg,
+    )
+
+    text = "Porta 70x210 cm"
+
+    width_candidates = list(orchestrator._parser_candidates("dimensione_larghezza", None, text))
+    assert width_candidates, "expected width candidate from dimensions"
+    width_candidate = width_candidates[0]
+    assert width_candidate["unit"] == "mm"
+    assert pytest.approx(width_candidate["value"], rel=1e-3) == 700.0
+
+    height_candidates = list(orchestrator._parser_candidates("dimensione_altezza", None, text))
+    assert height_candidates, "expected height candidate from dimensions"
+    height_candidate = height_candidates[0]
+    assert height_candidate["unit"] == "mm"
+    assert pytest.approx(height_candidate["value"], rel=1e-3) == 2100.0
+


### PR DESCRIPTION
## Summary
- ensure the width dimension heuristic keeps the first value for two-value strings while retaining other behaviors
- add a regression test covering width and height parsing for door-like text

## Testing
- pytest tests/test_parsers_dimensions.py tests/test_orchestrator_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfe1e45908322924e90958583a7b7