### PR TITLE
Document production resource setup and add config inspection CLI

### DIFF
--- a/docs/production_resource_setup.md
+++ b/docs/production_resource_setup.md
@@ -1,0 +1,102 @@
+# Giorno 1 – Blocco percorsi e versioning del registry
+
+Questa guida documenta le attività completate per il Giorno 1 della roadmap verso la messa in produzione del workflow di estrazione. L'obiettivo è rendere ripetibile la risoluzione dei percorsi critici (knowledge pack, registry, lexicon) e fissare la versione del registry da utilizzare in produzione.
+
+## 1. Inventario centralizzato dei percorsi
+
+Il modulo `robimb.config` espone la classe `ResourcePaths` che normalizza i percorsi partendo da:
+
+- variabili d'ambiente (`ROBIMB_*`), oppure
+- un file di configurazione esterno puntato da `ROBIMB_CONFIG_FILE`.
+
+Per rendere trasparente questo passaggio è stato aggiunto il comando CLI:
+
+```bash
+poetry run robimb config paths
+```
+
+Il comando restituisce un JSON con tutti i percorsi risolti, indicando per ciascuno se esiste e il tipo di risorsa (file o directory). Esempio di output abbreviato:
+
+```json
+{
+  "config_source": "environment",
+  "paths": {
+    "resources_dir": {"path": "/app/resources", "exists": true, "kind": "directory"},
+    "registry_path": {"path": "/app/resources/data/properties/registry.json", "exists": true, "kind": "file"}
+  },
+  "registry": {
+    "path": "/app/resources/data/properties/registry.json",
+    "status": "ok",
+    "detected_version": "0.2.0",
+    "version_matches": true
+  }
+}
+```
+
+Per generare un lockfile consumabile dalla CI/CD è disponibile l'azione:
+
+```bash
+poetry run robimb config lockfile --output outputs/resource-paths.json
+```
+
+Il file prodotto (`outputs/resource-paths.json`) può essere archiviato come artefatto di build così da verificare in modo deterministico cosa verrà deployato.
+
+## 2. Variabili d'ambiente supportate
+
+| Variabile | Descrizione | Valore di default |
+| --- | --- | --- |
+| `ROBIMB_RESOURCES_DIR` | Directory base delle risorse condivise | `<project_root>/resources` |
+| `ROBIMB_DATA_DIR` | Directory dati derivati (registry, prompts, lexicon) | `<resources_dir>/data` |
+| `ROBIMB_PACK_DIR` | Cartella con il knowledge pack esportato | `<resources_dir>/pack` |
+| `ROBIMB_REGISTRY_PATH` | File JSON del registry delle categorie | `<data_dir>/properties/registry.json` |
+| `ROBIMB_LEXICON_DIR` | Radice delle tassonomie per estrazione | `<data_dir>/properties/lexicon` |
+| `ROBIMB_PROMPTS_PATH` | File JSON con i prompt deterministici | `<data_dir>/properties/prompts.json` |
+| `ROBIMB_BRANDS_PATH` | Lexicon marchi correnti | `<lexicon_dir>/brands.json` |
+| `ROBIMB_BRANDS_LEGACY_PATH` | Lexicon marchi legacy | `<lexicon_dir>/brands.txt` |
+| `ROBIMB_MATERIALS_PATH` | Lexicon materiali corrente | `<lexicon_dir>/materials.json` |
+| `ROBIMB_MATERIALS_LEGACY_PATH` | Lexicon materiali legacy | `<lexicon_dir>/materials.txt` |
+| `ROBIMB_STANDARDS_PATH` | Lexicon norme correnti | `<lexicon_dir>/norms.json` |
+| `ROBIMB_STANDARDS_BY_CATEGORY` | Mappatura norme per categoria | `<lexicon_dir>/norms_by_category.json` |
+| `ROBIMB_PRODUCERS_PATH` | Produttori per categoria | `<lexicon_dir>/producers_by_category.json` |
+| `ROBIMB_COLORS_RAL_PATH` | Tavola colori RAL | `<lexicon_dir>/colors_ral.json` |
+| `ROBIMB_STANDARDS_PREFIXES_PATH` | Prefissi norme | `<lexicon_dir>/standards_prefixes.json` |
+| `ROBIMB_CONFIG_FILE` | File TOML/YAML alternativo con blocco percorsi | _(non definito)_ |
+
+> Suggerimento: valorizzare esplicitamente queste variabili nell'orchestratore (es. Helm chart, GitHub Action) evita derive fra ambienti e consente di accorgersi tempestivamente di path errati.
+
+## 3. Template di configurazione
+
+Per ambienti in cui si preferisce versionare un file di configurazione è stato introdotto `resources/config/production.sample.toml`:
+
+```toml
+[paths]
+resources = "../resources"
+data = "../resources/data"
+pack = "../resources/pack"
+registry = "../resources/data/properties/registry.json"
+lexicon = "../resources/data/properties/lexicon"
+prompts = "../resources/data/properties/prompts.json"
+
+[paths.lexicon]
+brands = "../resources/data/properties/lexicon/brands.json"
+brands_legacy = "../resources/data/properties/lexicon/brands.txt"
+materials = "../resources/data/properties/lexicon/materials.json"
+materials_legacy = "../resources/data/properties/lexicon/materials.txt"
+standards = "../resources/data/properties/lexicon/norms.json"
+standards_by_category = "../resources/data/properties/lexicon/norms_by_category.json"
+producers = "../resources/data/properties/lexicon/producers_by_category.json"
+colors_ral = "../resources/data/properties/lexicon/colors_ral.json"
+standards_prefixes = "../resources/data/properties/lexicon/standards_prefixes.json"
+```
+
+Per utilizzarlo impostare `ROBIMB_CONFIG_FILE=/percorso/production.toml` prima di lanciare la pipeline.
+
+## 4. Versione del registry fissata
+
+L'inventario registra anche la versione del registry (`metadata.version`) assicurandosi che corrisponda alla baseline di produzione `0.2.0`. In caso di mismatch il comando termina segnalando `"version_matches": false`, permettendo di bloccare il deploy via job CI.
+
+Il registry ufficiale rimane quello presente in `resources/data/properties/registry.json` (schema `property-registry-v1`). Qualsiasi modifica dovrà aggiornare la versione e passare per una nuova approvazione.
+
+---
+
+Con queste azioni il Giorno 1 è completo: i percorsi fondamentali sono inventariati e congelati, mentre la versione del registry è monitorata automaticamente durante i rilasci.

--- a/resources/config/production.sample.toml
+++ b/resources/config/production.sample.toml
@@ -1,0 +1,18 @@
+[paths]
+resources = "../resources"
+data = "../resources/data"
+pack = "../resources/pack"
+registry = "../resources/data/properties/registry.json"
+lexicon = "../resources/data/properties/lexicon"
+prompts = "../resources/data/properties/prompts.json"
+
+[paths.lexicon]
+brands = "../resources/data/properties/lexicon/brands.json"
+brands_legacy = "../resources/data/properties/lexicon/brands.txt"
+materials = "../resources/data/properties/lexicon/materials.json"
+materials_legacy = "../resources/data/properties/lexicon/materials.txt"
+standards = "../resources/data/properties/lexicon/norms.json"
+standards_by_category = "../resources/data/properties/lexicon/norms_by_category.json"
+producers = "../resources/data/properties/lexicon/producers_by_category.json"
+colors_ral = "../resources/data/properties/lexicon/colors_ral.json"
+standards_prefixes = "../resources/data/properties/lexicon/standards_prefixes.json"

--- a/src/robimb/cli/config.py
+++ b/src/robimb/cli/config.py
@@ -1,0 +1,138 @@
+"""Utility commands to inspect and validate robimb resource paths."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Dict, Tuple
+
+import typer
+
+from ..config import ResourcePaths, get_settings
+
+__all__ = ["app"]
+
+app = typer.Typer(
+    help="Strumenti di diagnostica per la configurazione del knowledge pack.",
+    add_completion=False,
+)
+
+
+def _inventory(paths: ResourcePaths) -> Dict[str, Dict[str, str | bool]]:
+    def describe(path_str: str) -> Tuple[str, bool, str]:
+        path = Path(path_str)
+        exists = path.exists()
+        if path.is_dir():
+            kind = "directory"
+        elif path.is_file():
+            kind = "file"
+        else:
+            kind = "missing"
+        return str(path), exists, kind
+
+    inventory: Dict[str, Dict[str, str | bool]] = {}
+    for key, value in paths.as_dict().items():
+        resolved, exists, kind = describe(value)
+        inventory[key] = {
+            "path": resolved,
+            "exists": exists,
+            "kind": kind,
+        }
+    return inventory
+
+
+def _check_registry_version(registry_path: Path, expected_version: str) -> Dict[str, str | bool]:
+    if not registry_path.exists():
+        return {
+            "path": str(registry_path),
+            "status": "missing",
+            "version_matches": False,
+        }
+
+    try:
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        return {
+            "path": str(registry_path),
+            "status": f"invalid_json: {exc}",
+            "version_matches": False,
+        }
+
+    metadata = payload.get("metadata") if isinstance(payload, dict) else None
+    version = ""
+    schema = ""
+    if isinstance(metadata, dict):
+        version = str(metadata.get("version", ""))
+        schema = str(metadata.get("schema", "")) if metadata.get("schema") else ""
+
+    return {
+        "path": str(registry_path),
+        "status": "ok",
+        "detected_version": version,
+        "schema": schema,
+        "version_matches": version == expected_version,
+    }
+
+
+@app.command("paths")
+def show_paths(
+    config_file: Path = typer.Option(
+        None,
+        "--config-file",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Configurazione TOML/YAML alternativa da usare al posto delle variabili d'ambiente.",
+    ),
+    refresh: bool = typer.Option(
+        False,
+        "--refresh",
+        help="Ignora la cache e ricostruisce le impostazioni partendo da variabili d'ambiente o file.",
+    ),
+    check_registry: bool = typer.Option(
+        True,
+        "--check-registry/--no-check-registry",
+        help="Valida la versione del registry rispetto al riferimento di produzione (0.2.0).",
+    ),
+) -> None:
+    """Stampa i percorsi risolti dal resolver ``ResourcePaths`` in formato JSON."""
+
+    settings = get_settings(refresh=refresh, config_file=config_file)
+    payload = {
+        "config_source": str(config_file) if config_file else "environment",
+        "paths": _inventory(settings),
+    }
+
+    if check_registry:
+        payload["registry"] = _check_registry_version(settings.registry_path, expected_version="0.2.0")
+
+    typer.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+@app.command("lockfile")
+def generate_lockfile(
+    output: Path = typer.Option(
+        Path("outputs/resource-paths.json"),
+        "--output",
+        dir_okay=False,
+        writable=True,
+        help="File JSON da produrre con l'inventario dei percorsi.",
+    ),
+    config_file: Path = typer.Option(
+        None,
+        "--config-file",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Configurazione TOML/YAML alternativa da usare per l'inventario.",
+    ),
+) -> None:
+    """Persisti un lockfile dei percorsi per tracciarli nelle pipeline CI/CD."""
+
+    settings = get_settings(refresh=True, config_file=config_file)
+    payload = {
+        "paths": _inventory(settings),
+        "registry": _check_registry_version(settings.registry_path, expected_version="0.2.0"),
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    typer.echo(json.dumps({"output": str(output)}, indent=2, ensure_ascii=False))

--- a/src/robimb/cli/main.py
+++ b/src/robimb/cli/main.py
@@ -5,6 +5,7 @@ import typer
 
 from .._version import __version__
 from ..utils.sampling import sample_one_record_per_category
+from .config import app as config_app
 from .convert import convert_command
 from .evaluate import evaluate_command
 from .extract import app as extract_app
@@ -34,6 +35,7 @@ def version_callback(
 
 app.command("convert", help="Prepara dataset, label map e maschere ontologiche.")(convert_command)
 app.add_typer(extract_app, name="extract")
+app.add_typer(config_app, name="config")
 app.command("evaluate", help="Valuta un modello esportato su un dataset etichettato.")(evaluate_command)
 app.command("pack", help="Impacchetta le cartelle delle proprietà in registry/extractors.")(pack_command)
 


### PR DESCRIPTION
## Summary
- add a Typer `config` sub-command to inspect resolved `ResourcePaths`, generate lockfiles, and validate the registry version
- document the production path locking procedure and provide a production configuration template

## Testing
- PYTHONPATH=src python - <<'PY'
from robimb.config import get_settings
from robimb.cli import config as config_cli

settings = get_settings(refresh=True)
print(config_cli._inventory(settings)['registry_path'])
print(config_cli._check_registry_version(settings.registry_path, expected_version='0.2.0')['version_matches'])
PY


------
https://chatgpt.com/codex/tasks/task_e_68de1e8af8ac8322ae1167254a79bfcb